### PR TITLE
Fix name conflict with Nemo.integrate

### DIFF
--- a/test/methods/risch/bronstein_examples.jl
+++ b/test/methods/risch/bronstein_examples.jl
@@ -1,5 +1,5 @@
 using AbstractAlgebra
-using Nemo
+import Nemo
 using SymbolicIntegration
 SI = SymbolicIntegration
 

--- a/test/methods/risch/test_algorithm_internals.jl
+++ b/test/methods/risch/test_algorithm_internals.jl
@@ -2,7 +2,7 @@ using Test
 using SymbolicIntegration
 using Symbolics
 using AbstractAlgebra
-using Nemo
+import Nemo
 
 @testset "[Risch] Algorithm Internals" begin
     # Test internal algorithm components to ensure they work with the new API

--- a/test/methods/risch/test_bronstein_examples.jl
+++ b/test/methods/risch/test_bronstein_examples.jl
@@ -2,7 +2,7 @@ using Test
 using SymbolicIntegration
 using Symbolics
 using AbstractAlgebra
-using Nemo
+import Nemo
 
 @testset "[Risch] Bronstein Algorithm Examples" begin
     # Examples from "Symbolic Integration I: Transcendental Functions" by Manuel Bronstein

--- a/test/methods/risch/test_complex_fields.jl
+++ b/test/methods/risch/test_complex_fields.jl
@@ -2,7 +2,7 @@ using Test
 using SymbolicIntegration
 using Symbolics
 using AbstractAlgebra
-using Nemo
+import Nemo
 
 @testset "[Risch] Complex Fields Operations" begin
     # Note: These tests use internal SymbolicIntegration functions


### PR DESCRIPTION
## Problem
Test files using both `using SymbolicIntegration` and `using Nemo` cause name conflicts because both packages export an `integrate` function. This causes `UndefVarError` in tests, preventing CompatHelper PRs #16 and #17 from passing.

## Solution
Changed `using Nemo` to `import Nemo` in test files to avoid exporting Nemo's symbols while still allowing access to Nemo functions via qualified names (e.g., `Nemo.QQ`).

## Testing
- ✅ PR #16 tests pass: 102 passed, 1 broken, 103 total (1m36s)
- ✅ PR #17 tests pass: 102 passed, 1 broken, 103 total (1m37s)

## Files Changed
- `test/methods/risch/test_complex_fields.jl`
- `test/methods/risch/test_bronstein_examples.jl`
- `test/methods/risch/test_algorithm_internals.jl`
- `test/methods/risch/bronstein_examples.jl`

## Related Issues
Fixes test failures in:
- #16 (CompatHelper: bump compat for AbstractAlgebra to 0.47)
- #17 (CompatHelper: bump compat for Nemo to 0.52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>