### PR TITLE
Fix Vararg syntax error for Julia 1.12 compatibility

### DIFF
--- a/src/methods/risch/frontend.jl
+++ b/src/methods/risch/frontend.jl
@@ -725,7 +725,7 @@ function TowerOfDifferentialFields(terms::Vector{Term})  where
 end
 
 
-@variables ∫(.., ..)
+SymbolicUtils.@syms ∫(::Any, ::Any)::Real
 
 """
     integrate(f, x; kwargs...)


### PR DESCRIPTION
## Summary

Fixes package loading error that prevented v3.2.0 registration by replacing invalid Vararg syntax with SymbolicUtils.@syms.

## Problem

The package registration for v3.2.0 failed with:
```
TypeError: in Tuple, in non-final parameter, expected Type, got Vararg
```

This occurred at `src/methods/risch/frontend.jl:728` where the code used:
```julia
@variables ∫(.., ..)
```

This syntax is incompatible with Julia 1.12's type system restrictions on Vararg placement.

## Solution

Changed line 728 to:
```julia
SymbolicUtils.@syms ∫(::Any, ::Any)::Real
```

This properly declares the unevaluated integral symbol as a function taking exactly two arguments (the integrand and the variable), which matches how it's used throughout the codebase (lines 806, 823, 828).

## Testing

- ✓ Package loads successfully and precompiles all 3400 integration rules
- ✓ Tested with existing test files that use the integral symbol
- ✓ Compatible with Julia 1.12 type system

## Related Issues

This fixes the package registration failure for v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)