### PR TITLE
Add Julia ecosystem to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
+enable-beta-ecosystems: true # Julia ecosystem
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
@@ -8,3 +9,15 @@ updates:
     ignore:
       - dependency-name: "crate-ci/typos"
         update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+      - "/test"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
## Summary

This PR adds Julia ecosystem support to the existing Dependabot configuration.

**Changes:**
- Updated `.github/dependabot.yml` to include Julia ecosystem (beta feature)

**Benefits:**
- Native GitHub Dependabot now handles Julia dependencies
- Groups all Julia package updates into a single PR

## Configuration

The updated Dependabot configuration now includes:
- Updates GitHub Actions weekly (existing)
- Updates Julia dependencies daily (new)
- Groups all Julia package updates into a single PR (new)

## References

- [Dependabot documentation](https://docs.github.com/en/code-security/dependabot)
- Example: https://github.com/JuliaDiff/DifferentiationInterface.jl/blob/main/.github/dependabot.yml

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)