### PR TITLE
Fix CI runner crashes: cycle detection, SymbolicUtils ≥ 4.27 floor, macOS arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.group }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,14 +31,11 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - name: Run tests

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ FresnelIntegrals = "0.2.0"
 HypergeometricFunctions = "0.3.28"
 Nemo = "0.51, 0.52, 0.53, 0.54, 0.55"
 PolyLog = "2.6.0"
-SymbolicUtils = "4"
+SymbolicUtils = "4.27"
 Symbolics = "7"
 julia = "1.10"
 

--- a/src/methods/rule_based/frontend.jl
+++ b/src/methods/rule_based/frontend.jl
@@ -76,12 +76,20 @@ if it finds a symbol or a real (!iscall) stop the recursion
 if it finds a ∫ operation call apply_rule
 if it finds another operation continue the recursion in the arguments. (for cases
     like 1+∫(...) )
+
+`visited` accumulates integrals already rewritten on the *current* linear
+chain so multi-rule cycles (which `apply_rule`'s single-step identity
+check cannot detect) terminate. Sibling subtrees start with a fresh set.
 """
 # TODO add threaded for speed?
-function repeated_prewalk(expr)
+function repeated_prewalk(expr; visited::Set=Set())
     !iscall(expr) && return expr # termination condition
-    
+
     if operation(expr)===∫
+        if expr in visited
+            return expr
+        end
+        push!(visited, expr)
         (new_expr,success) = apply_rule(expr)
         # # r1 and r2 are needed bc of neim problem
         # if !success
@@ -111,7 +119,7 @@ function repeated_prewalk(expr)
         if success
             # cannot directly return new_expr because even if a rule
             # is applied the result could still contain integrals
-            return repeated_prewalk(new_expr)
+            return repeated_prewalk(new_expr; visited=visited)
         else
             # TODO Can this be a bad idea sometimes?
             simplified_expr = simplify(expr, expand=true)


### PR DESCRIPTION
Fixes the things that prevent the difficult-test job from producing a meaningful per-integral signal. Does **not** touch the test gate — `count(x -> x != 0, …) == 0` stays as the strict bar, so CI will still red-fail on integrals the engine doesn't yet solve. Those are genuine engine work items to address separately; this PR just stops the runner from aborting before they can be observed.

## What's in scope

**1. `ci: drop hard-coded x64 arch so macOS arm64 runners work`**
GitHub's `macos-latest` is now Apple Silicon, so `setup-julia@v3` errored out on `arch: x64` before the test step ever ran. Drop the `arch` matrix axis and let `setup-julia` auto-detect per OS.

**2. `fix(rule_based): break multi-rule rewrite cycles in repeated_prewalk`**
Some Apostol rationals (e.g. `(2+x)/(x+x²)`, `1/(x·(1+x²)²)`) sent the rule-based engine into a 2-step rewrite cycle: rule A rewrites `∫f` to `∫g`, rule B rewrites `∫g` back to `∫f`. `apply_rule`'s existing `result === problem` guard only catches single-step identity loops, so `repeated_prewalk` recursed forever and eventually overflowed the stack deep enough to fault Julia's type inference of `RuleRewriteError` itself — `signal (6.-6): Aborted`, no recovery possible from any user-level `try`/`catch`. Thread a `visited::Set` through the linear rewrite chain; on a re-visit, return the integral unevaluated (which the suite then classifies as a normal `[ fail ]`). Sibling subtrees start with a fresh set.

**3. `build: require SymbolicUtils ≥ 4.27`**
v4.27 is the first release containing the `poly_to_gcd_form` concrete-eltype fix (JuliaSymbolics/SymbolicUtils.jl#906). Without it, `simplify(diff; expand=true)` inside the difficult-test verifier throws `MethodError(MP.Term{T,M} where T, …)` on several Apostol rationals (e.g. `(2-x+2x²-x³+x⁴)/((-1+x)·(2+x²)²)`, `1/(-1+x²)²`), masking the underlying integration result with a verifier crash.

## What's not in scope

- Changes to the test gate. `count(x -> x != 0, …) == 0` is preserved as-is.
- Whitelisting / skipping integrals the engine can't currently solve.
- Engine coverage work to actually pass the strict bar.

So CI on this PR is expected to be **red** until the engine learns to solve the remaining Apostol cases — and that red is informative now, not a SIGABRT.

## Local validation (Julia 1.10.11, ubuntu, this branch)

With all three fixes in:

```
[Rule Based] Integration of 177 functions: 93 ok, 50 fail, 34 maybe-fail, 0 errored
[Risch]      Integration of 177 functions: 29 ok, 134 fail, 14 maybe-fail, 0 errored
Wallclock: ~2m46s
```

Compared to `main` against the same SymbolicUtils v4.27.0: SIGABRT partway through Apostol when the cycle bug overflows the stack. So 'completes the suite + 122/354 fails' is strictly more informative than the current 'aborts mid-suite with no scoreboard'.

## Test plan

- [x] Easy tests pass on Julia 1.10.11 locally (94 pass, 1 pre-existing broken).
- [x] Difficult-test runner runs to completion on Julia 1.10.11 locally (no SIGABRT, no MethodError, no `[except]` events). The strict bar still fails on the unsolved integrals — that's the intended state.
- [x] Two known cyclic integrals (`(2+x)/(x+x²)`, `1/(x·(1+x²)²)`) terminate cleanly instead of hanging/SIGABRTing.
- [ ] CI red here on the genuine coverage gap (expected); each crash class fixed.

Draft PR — please ignore until reviewed by @ChrisRackauckas.