### PR TITLE
Small corrections to bessel pr

### DIFF
--- a/src/methods/rule_based/rules2/8 Special functions/8.1 Bessel functions.jl
+++ b/src/methods/rule_based/rules2/8 Special functions/8.1 Bessel functions.jl
@@ -1,6 +1,13 @@
 file_rules = [
     #(* ::Subsection::Closed:: *)
     #(* 8.1 Bessel functions *)
+    ("8_1_0",
+    :(*(~~a)) => :(
+    let
+        terms = distribute_special_function_product(arguments(~a), ~x)
+        terms === nothing ? nothing : sum(map(term -> ∫(term, ~x), terms))
+    end
+    ))
 
     (
         "8_1_1",

--- a/src/methods/rule_based/rules2/9 Miscellaneous/0.1 Integrand simplification rules.jl
+++ b/src/methods/rule_based/rules2/9 Miscellaneous/0.1 Integrand simplification rules.jl
@@ -1,13 +1,6 @@
 file_rules = [
+# 0_1_0: integral of the sum is sum of the integrals
 ("0_1_0", :(+(~~a)) => :(sum(map(f -> ∫(f,~x), arguments(~a)))) )
-
-("0_1_1",
-:(*(~~a)) => :(
-let
-    terms = distribute_special_function_product(arguments(~a), ~x)
-    terms === nothing ? nothing : sum(map(term -> ∫(term, ~x), terms))
-end
-))
 
 ("0_1_6",
 :((~!u)*((~!a)*(~v) + (~!b)*(~v) + (~!w))^(~!p)) => :(
@@ -28,6 +21,7 @@ end
     !contains_var((~a), (~x)) ?
 (~a)*(~x) : nothing))
 
+# constants out of the integral
 ("0_1_12",
 :(*(~~a)) => :(
 let

--- a/test/methods/rule_based/test_rule2.jl
+++ b/test/methods/rule_based/test_rule2.jl
@@ -47,7 +47,7 @@ end
     @test eq(SymbolicIntegration.rule2(r, 1/exp(x)), -x)
 end
 
-# This thest is to test functions that are shorthand notation for powers, like exp and sqrt
+# This testset is for functions that are shorthand notation for powers, like exp and sqrt
 @testset "power shorthand functions in rules" begin
     @syms x
     rs = :(sqrt(~x)) => :(~x)

--- a/test/methods/rule_based/test_rule2.jl
+++ b/test/methods/rule_based/test_rule2.jl
@@ -47,7 +47,8 @@ end
     @test eq(SymbolicIntegration.rule2(r, 1/exp(x)), -x)
 end
 
-@testset "special functions in rules" begin
+# This thest is to test functions that are shorthand notation for powers, like exp and sqrt
+@testset "power shorthand functions in rules" begin
     @syms x
     rs = :(sqrt(~x)) => :(~x)
     @test eq(SymbolicIntegration.rule2(rs, sqrt(x)), x)
@@ -55,19 +56,6 @@ end
     rs = :(exp(~x)) => :(~x)
     @test eq(SymbolicIntegration.rule2(rs, exp(x+1)), x+1)
     @test eq(SymbolicIntegration.rule2(rs, ℯ^x), x)
-
-    rbj = :(besselj(~nu, ~z)) => :(~nu, ~z)
-    besselj_match = SymbolicUtils.arguments(SymbolicIntegration.rule2(rbj, SpecialFunctions.besselj(0, x)))
-    @test SymbolicUtils.unwrap_const(besselj_match[1]) == 0
-    @test isequal(besselj_match[2], x)
-
-    rbi = :(besseli(~nu, ~z)) => :(~nu, ~z)
-    besseli_match = SymbolicUtils.arguments(SymbolicIntegration.rule2(rbi, SpecialFunctions.besseli(1, x)))
-    @test SymbolicUtils.unwrap_const(besseli_match[1]) == 1
-    @test isequal(besseli_match[2], x)
-
-    rai = :(airyai(~z)) => :(~z)
-    @test eq(SymbolicIntegration.rule2(rai, SpecialFunctions.airyai(x)), x)
 end
 
 @testset "Segment" begin

--- a/test/methods/rule_based/test_special_functions.jl
+++ b/test/methods/rule_based/test_special_functions.jl
@@ -4,7 +4,7 @@ using SpecialFunctions
 using Symbolics
 
 # TODO move these tests to rundifficulttests.jl together with all the other integrals
-# putting all the integrals in a test files with the soultions
+# putting all the integrals in a test files with the solutions
 
 @testset "RuleBased special-function integrals" begin
     @variables x a

--- a/test/methods/rule_based/test_special_functions.jl
+++ b/test/methods/rule_based/test_special_functions.jl
@@ -3,6 +3,9 @@ using SymbolicIntegration
 using SpecialFunctions
 using Symbolics
 
+# TODO move these tests to rundifficulttests.jl together with all the other integrals
+# putting all the integrals in a test files with the soultions
+
 @testset "RuleBased special-function integrals" begin
     @variables x a
     method = RuleBasedMethod()


### PR DESCRIPTION
- in test/methods/rule_based/test_rule2.jl there is a testset called "special functions in rules" but is not meant to test the special functions form SpecialFunctions.jl, is meant to test only `exp` and `sqrt`. I called it special because they are shorthand notation for powers, and this complicates a bit the mathcing logic. So the test you added are not needded, i removed them and changed the name to a clearer one
- I dont really like the addition of rule 0_1_1 in the src/methods/rule_based/rules2/9 Miscellaneous/0.1 Integrand simplification rules.jl file, because those are rules executed for every expression and for most expressions this rule is useless. I moved it to src/methods/rule_based/rules2/8 Special functions/8.1 Bessel functions.jl with the index 8_1_0 so still before the other special functions rules (the tests still pass)
- would be cool to also add rules for functions like [`besselj0`](https://specialfunctions.juliamath.org/stable/functions_overview/#Bessel-Functions) becasue this is whats happening now:
```
julia> integrate(x * SpecialFunctions.besselj(0, 2x))
(1//2)*x*besselj(1, 2x)

julia> integrate(x * SpecialFunctions.besselj0(2x))
∫(x*besselj0(2x), x)
```
but i actually dont know it that's really useful
- test/methods/rule_based/test_special_functions.jl is ok for now because testing is a bit messy but the way to add tests is to insert them in a file in test/test_files add that filename to the list in test/rundifficulttests.jl

