### PR TITLE
Document optional Maxima integration backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Spell Check](https://github.com/JuliaSymbolics/SymbolicIntegration.jl/actions/workflows/spellcheck.yml/badge.svg?branch=main)](https://github.com/JuliaSymbolics/SymbolicIntegration.jl/actions/workflows/spellcheck.yml)
 
 
-SymbolicIntegration.jl solves indefinite integrals (find primitives of functions) using one of the implemented algorithms: Risch method and Rule based method
+SymbolicIntegration.jl solves indefinite integrals (find primitives of functions) using one of the implemented algorithms: Risch method and Rule based method.
 
 # Usage
 
@@ -46,7 +46,7 @@ No rule found for ∫(abs(x), x)
 ```
 
 # Integration Methods
-Currently two methods are implemented: **Risch algorithm** and **Rule based integration**.
+Currently two methods are implemented in this package: **Risch algorithm** and **Rule based integration**.
 
 feature | Risch | Rule based
 --------|-------|-----------
@@ -62,6 +62,20 @@ multiple symbols | ❌ | ✅
 
 More info about them in the [methods documentation](https://docs.sciml.ai/SymbolicIntegration/dev/methods/overview/)
 
+### Optional external methods
+
+Additional integration methods can be provided by external packages. For example,
+[SymbolicIntegrationMaxima.jl](https://github.com/Amin-El-Sayed/SymbolicIntegrationMaxima.jl)
+adds a `MaximaMethod` backend that delegates to a local Maxima installation:
+
+```julia
+using SymbolicIntegration, Symbolics, SymbolicIntegrationMaxima
+
+@variables x
+integrate(exp(-x^2), x, MaximaMethod())
+```
+
+The Maxima backend is optional and is not loaded by SymbolicIntegration.jl itself.
 
 ### Risch Method
 Complete symbolic integration using the Risch algorithm from Manuel Bronstein's "Symbolic Integration I: Transcendental Functions".

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 CurrentModule = SymbolicIntegration
 ```
 
-SymbolicIntegration.jl lets you solve indefinite integrals (finds primitives) in Julia [Symbolics.jl](https://docs.sciml.ai/Symbolics/stable/). It does so using two symbolic integration algorithms: Risch algorithm and Rule based algorithm.
+SymbolicIntegration.jl lets you solve indefinite integrals (finds primitives) in Julia [Symbolics.jl](https://docs.sciml.ai/Symbolics/stable/). It does so using two built-in symbolic integration algorithms: Risch algorithm and Rule based algorithm.
 
 ## Installation
 
@@ -42,7 +42,7 @@ Also note that two different symbolic variables are assumed to be independent.
 
 ## Integration Methods
 
-SymbolicIntegration.jl provides two integration algorithms: Risch method and Rule based method.
+SymbolicIntegration.jl provides two built-in integration algorithms: Risch method and Rule based method.
 
 **Default Behavior:** When no method is explicitly specified, `integrate()` will first attempt the **Rule based method**. If it fails, it will then try with the **Risch method**.
 
@@ -59,6 +59,21 @@ hyperbolic functions  | ✅ | sometimes
 Nonelementary integrals | ❌ | most of them
 Special functions | ❌ | ❌
 multiple symbols | ❌ | ✅
+
+### Optional external methods
+
+External packages can provide additional integration methods. For example,
+[SymbolicIntegrationMaxima.jl](https://github.com/Amin-El-Sayed/SymbolicIntegrationMaxima.jl)
+adds a `MaximaMethod` backend that delegates integration to a local Maxima installation.
+
+```julia
+using SymbolicIntegration, Symbolics, SymbolicIntegrationMaxima
+
+@variables x
+integrate(exp(-x^2), x, MaximaMethod())
+```
+
+The Maxima backend is optional and is not loaded by SymbolicIntegration.jl itself.
 
 ### RuleBased
 This method uses a large number of integration rules that specify how to integrate various mathematical expressions.

--- a/docs/src/methods/overview.md
+++ b/docs/src/methods/overview.md
@@ -1,6 +1,6 @@
 # Integration Methods Overview
 
-SymbolicIntegration.jl uses a flexible method dispatch system that allows you to choose different integration algorithms. Two methods are implemented:
+SymbolicIntegration.jl uses a flexible method dispatch system that allows you to choose different integration algorithms. Two methods are implemented in this package:
 
 ## RischMethod
 
@@ -13,3 +13,9 @@ The **Risch method** is the complete algorithm for symbolic integration of eleme
 This method uses a large number of integration rules that specify how to integrate a vast class of mathematical expressions.
 
 [→ See detailed Rule based documentation](rulebased.md)
+
+## Optional external methods
+
+Additional packages can extend SymbolicIntegration.jl with their own integration methods.
+[SymbolicIntegrationMaxima.jl](https://github.com/Amin-El-Sayed/SymbolicIntegrationMaxima.jl)
+provides a `MaximaMethod` backend for users who want to delegate integrals to a local Maxima installation.


### PR DESCRIPTION
This adds a short documentation note for external integration methods, with SymbolicIntegrationMaxima.jl as an example optional backend.

The change intentionally keeps the built-in/default behavior unchanged:

- RischMethod and RuleBasedMethod are still described as the built-in methods.
- SymbolicIntegrationMaxima.jl is documented as an external package that provides MaximaMethod.
- The note mentions that the backend requires a local Maxima installation and is not loaded by SymbolicIntegration.jl itself.