### PR TITLE
Improve Maxima backend usability and result handling

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -35,6 +35,7 @@ erfi = "erfi"
 gamma = "gamma"
 loggamma = "loggamma"
 Numer = "Numer"
+numer = "numer"  # Maxima ev option for numerical evaluation
 
 # Technical terms
 integrand = "integrand"

--- a/README.md
+++ b/README.md
@@ -76,10 +76,17 @@ integrate(exp(-x^2), x, MaximaMethod())
 integrate(exp(-a * x), x, 0, Inf, MaximaMethod(); assumptions=(a > 0,))
 integrate(x^n * log(a * x), x, MaximaMethod();
           assumptions=(a > 0, maxima_notequal(n, -1)))
+
+# Exact simplification and numerical evaluation
+g = integrate(x^2 * exp(-x), x, 2, Inf, MaximaMethod())
+maxima_simplify(g)
+maxima_numeric(g; digits=40)
 ```
 
 The Maxima backend is optional, requires a local Maxima installation, and is not
-loaded by SymbolicIntegration.jl itself.
+loaded by SymbolicIntegration.jl itself. See the
+[Maxima backend guide](https://docs.sciml.ai/SymbolicIntegration/dev/methods/maxima/)
+for installation, assumptions, special functions, and REPL help.
 
 ### Risch Method
 Complete symbolic integration using the Risch algorithm from Manuel Bronstein's "Symbolic Integration I: Transcendental Functions".

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(
             "methods/overview.md",
             "methods/rulebased.md",
             "methods/risch.md",
+            "methods/maxima.md",
         ],
         "API Reference" => "api.md",
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,9 +62,9 @@ multiple symbols | ❌ | ✅
 
 ### Optional external methods
 
-Optional packages can provide additional integration methods. For example,
-the [`SymbolicIntegrationMaxima.jl`](https://github.com/JuliaSymbolics/SymbolicIntegration.jl/tree/main/lib/SymbolicIntegrationMaxima) subpackage
-adds a `MaximaMethod` backend that delegates integration to a local Maxima installation.
+Optional packages can provide additional integration methods. For example, the
+[`SymbolicIntegrationMaxima.jl`](methods/maxima.md) subpackage adds a
+`MaximaMethod` backend that delegates integration to a local Maxima installation.
 
 ```julia
 using SymbolicIntegration, Symbolics, SymbolicIntegrationMaxima
@@ -77,7 +77,8 @@ integrate(x^n * log(a * x), x, MaximaMethod();
 ```
 
 The Maxima backend is optional, requires a local Maxima installation, and is not
-loaded by SymbolicIntegration.jl itself.
+loaded by SymbolicIntegration.jl itself. The [Maxima backend guide](methods/maxima.md)
+covers assumptions, special functions, exact simplification, and numerical evaluation.
 
 ### RuleBased
 This method uses a large number of integration rules that specify how to integrate various mathematical expressions.

--- a/docs/src/methods/maxima.md
+++ b/docs/src/methods/maxima.md
@@ -1,0 +1,150 @@
+# Maxima backend
+
+`SymbolicIntegrationMaxima` is an optional subpackage that delegates symbolic
+integration and simplification to a local [Maxima](https://maxima.sourceforge.io/)
+installation. Results are converted back to Symbolics expressions, so they can
+be substituted, differentiated, simplified, or passed to Maxima again.
+
+## Installation
+
+Install the Julia package in the active environment:
+
+```julia
+using Pkg
+Pkg.add("SymbolicIntegrationMaxima")
+```
+
+Maxima itself is a separate executable:
+
+```text
+macOS:         brew install maxima
+Debian/Ubuntu: sudo apt install maxima
+Fedora:        sudo dnf install maxima
+Windows:       install the current win64.exe from https://maxima.sourceforge.io/download.html
+```
+
+The command `maxima` must be on `PATH`. For a nonstandard installation, pass its
+full path as `MaximaMethod(command="...")`. Check the setup from Julia with
+`maxima_status()`.
+
+## Integration
+
+```julia
+using Symbolics, SymbolicIntegration, SymbolicIntegrationMaxima
+
+@variables x a C n
+M = MaximaMethod(timeout=10)
+
+integrate(exp(-x^2), x, M)
+integrate(sin(x) / x, x, M)
+integrate(exp(-x), x, 0, Inf, M)
+integrate(sin(π * x)^2, x, 0, 1, M)
+```
+
+`expand_special_functions=true` is the default. It asks Maxima to reduce exact
+special-function values when an identity is available. For example:
+
+```julia
+integrate(x^2 * exp(-x), x, 2, Inf, M)
+# 10exp(-2)
+```
+
+Set `expand_special_functions=false` to preserve Maxima's default form, such as
+`gamma_incomplete(3, 2)`.
+
+## Assumptions
+
+Parameter-dependent improper integrals often have different convergence regions.
+The backend never silently assumes that parameters are positive. State the branch
+that applies to the calculation:
+
+```julia
+integrate(exp(-a * x), x, 0, Inf, M; assumptions=(a > 0,))
+
+integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, M;
+          assumptions=(C > 0,))
+# 0
+```
+
+The comma in a one-element tuple is required: use `(a > 0,)`, not `(a > 0)`.
+Reusable assumptions can be stored in the method:
+
+```julia
+Mpositive = MaximaMethod(timeout=10, assumptions=(a > 0, C > 0))
+```
+
+Supported context helpers include:
+
+```julia
+maxima_notequal(n, -1)       # notequal(n,-1)
+maxima_declare(n, :integer)  # declare(n,integer)
+maxima_statement("domain:complex")
+
+integrate(x^n * log(a * x), x, M;
+          assumptions=(a > 0, maxima_notequal(n, -1)))
+```
+
+`maxima_statement` is an expert escape hatch. Its text is sent directly to a
+fresh Maxima process for that call.
+
+When Maxima requests missing information, `MaximaError.kind` is `:assumption`.
+The error includes Maxima's question and examples of Julia assumption syntax.
+Choose an assumption only when it follows from the mathematical problem.
+
+## Exact and numerical results
+
+Use Maxima to simplify an existing result exactly:
+
+```julia
+g = gamma_incomplete(3, 2)
+maxima_simplify(g)
+# 10exp(-2)
+```
+
+Use `maxima_numeric` after substituting all free variables:
+
+```julia
+maxima_numeric(g)                 # Float64
+maxima_numeric(g; digits=50)      # BigFloat
+
+F = integrate(exp(-a * x), x, 0, 1, M)
+maxima_numeric(substitute(F, Dict(a => 2)))
+```
+
+If free variables remain, `maxima_numeric` raises a `MaximaError` instead of
+returning a partially evaluated expression.
+
+Known Maxima special functions are mapped explicitly. Unknown function names are
+kept as opaque `MaximaFunction` terms instead of losing the result. These terms
+roundtrip through `to_maxima` and `maxima_simplify`; `maxima_numeric` can
+evaluate them when Maxima knows a numerical value.
+
+## Configuration and help
+
+```julia
+M = MaximaMethod(
+    command="maxima",
+    timeout=10,
+    validate=false,
+    simplify_result=true,
+    expand_special_functions=true,
+    assumptions=(),
+)
+
+maxima_help()
+maxima_status(M)
+```
+
+Julia help mode contains the detailed API documentation:
+
+```text
+?MaximaMethod
+?maxima_integrate
+?maxima_simplify
+?maxima_numeric
+```
+
+Each call starts a fresh Maxima process. This costs startup time, but prevents
+assumptions and assignments from leaking between calculations. Unevaluated
+integrals and conditional Maxima expressions are reported explicitly rather than
+being presented as solved results.

--- a/docs/src/methods/overview.md
+++ b/docs/src/methods/overview.md
@@ -17,7 +17,7 @@ This method uses a large number of integration rules that specify how to integra
 ## Optional external methods
 
 Additional packages can extend SymbolicIntegration.jl with their own integration methods.
-The [`SymbolicIntegrationMaxima.jl`](https://github.com/JuliaSymbolics/SymbolicIntegration.jl/tree/main/lib/SymbolicIntegrationMaxima) subpackage
-provides a `MaximaMethod` backend for users who want to delegate integrals to a local Maxima installation.
+The [`SymbolicIntegrationMaxima.jl`](maxima.md) subpackage provides a
+`MaximaMethod` backend for users who want to delegate integrals to a local Maxima installation.
 It supports indefinite and definite integrals, plus Maxima assumptions such as
 `assumptions=(a > 0, maxima_notequal(n, -1))` for parameter-dependent integrals.

--- a/lib/SymbolicIntegrationMaxima/Project.toml
+++ b/lib/SymbolicIntegrationMaxima/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicIntegrationMaxima"
 uuid = "6f8f0c92-4498-4b29-a8cc-7d11f58db8c9"
 authors = ["Amin Elsayed and contributors"]
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT"
 description = "Optional Maxima backend for SymbolicIntegration.jl"
 

--- a/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
+++ b/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
@@ -205,7 +205,7 @@ function maxima_call(expr::AbstractString; command::AbstractString="maxima", tim
     stdout_pipe = Pipe()
     stderr_pipe = Pipe()
     proc = try
-        run(pipeline(cmd; stdout=stdout_pipe, stderr=stderr_pipe), wait=false)
+        run(pipeline(cmd; stdin=devnull, stdout=stdout_pipe, stderr=stderr_pipe), wait=false)
     catch err
         if err isa Base.IOError
             message = "Could not start Maxima executable `$(command)`. " *

--- a/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
+++ b/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
@@ -7,8 +7,9 @@ using SpecialFunctions
 
 import SymbolicIntegration: AbstractIntegrationMethod, integrate
 
-export MaximaMethod, MaximaError, maxima_available, maxima_call
-export to_maxima, from_maxima, maxima_integrate
+export MaximaMethod, MaximaError, MaximaFunction, maxima_available, maxima_call
+export to_maxima, from_maxima, maxima_integrate, maxima_simplify, maxima_numeric
+export maxima_help, maxima_status
 export maxima_declare, maxima_notequal, maxima_statement
 export gamma_incomplete, gamma_incomplete_lower, gamma_incomplete_regularized
 export gamma_incomplete_generalized, expintegral_e, expintegral_e1, expintegral_ei
@@ -17,42 +18,70 @@ export expintegral_chi, sin_integral, cos_integral, erf_generalized
 export fresnel_s, fresnel_c, beta_incomplete, beta_incomplete_regularized
 export elliptic_f, elliptic_e, elliptic_eu, elliptic_pi, elliptic_kc, elliptic_ec
 export jacobi_sn, jacobi_cn, jacobi_dn, jacobi_am
-export hypergeometric, struve_h, struve_l
+export hypergeometric, struve_h, struve_l, polylog
+export hankel_1, hankel_2, parabolic_cylinder_d, lambert_w
+export assoc_legendre_p, assoc_legendre_q
 
 const RESULT_START = "__SYMBOLIC_INTEGRATION_MAXIMA_RESULT_START__"
 const RESULT_END = "__SYMBOLIC_INTEGRATION_MAXIMA_RESULT_END__"
 
-"""
-    gamma_incomplete(a, z), expintegral_e(n, z), elliptic_f(phi, m), ...
+const MAXIMA_PLACEHOLDER_FUNCTIONS = (
+    :gamma_incomplete, :gamma_incomplete_lower, :gamma_incomplete_regularized,
+    :gamma_incomplete_generalized, :expintegral_e, :expintegral_e1,
+    :expintegral_ei, :expintegral_li, :expintegral_si, :expintegral_ci,
+    :expintegral_shi, :expintegral_chi, :sin_integral, :cos_integral,
+    :erf_generalized, :fresnel_s, :fresnel_c, :beta_incomplete,
+    :beta_incomplete_regularized, :elliptic_f, :elliptic_e, :elliptic_eu,
+    :elliptic_pi, :elliptic_kc, :elliptic_ec, :jacobi_sn, :jacobi_cn,
+    :jacobi_dn, :jacobi_am, :hypergeometric, :struve_h, :struve_l,
+    :polylog, :hankel_1, :hankel_2, :parabolic_cylinder_d, :lambert_w,
+    :assoc_legendre_p, :assoc_legendre_q,
+)
 
-Symbolic placeholders for special functions that Maxima can return but
-Symbolics.jl does not currently provide as standard symbolic functions.
-They are exported so callers can inspect and dispatch on these results.
+const MAXIMA_INDEXED_PLACEHOLDERS = (:polylog, :assoc_legendre_p, :assoc_legendre_q)
+const MAXIMA_PLAIN_PLACEHOLDERS = Tuple(
+    name for name in MAXIMA_PLACEHOLDER_FUNCTIONS if name ∉ MAXIMA_INDEXED_PLACEHOLDERS)
+
 """
-# Maxima can return special functions that Symbolics does not define by default.
-# Keep them as symbolic calls so substitution and further algebra still work.
-for fname in (
-        :gamma_incomplete, :gamma_incomplete_lower, :gamma_incomplete_regularized,
-        :gamma_incomplete_generalized, :expintegral_e, :expintegral_e1,
-        :expintegral_ei, :expintegral_li, :expintegral_si, :expintegral_ci,
-        :expintegral_shi, :expintegral_chi, :sin_integral, :cos_integral,
-        :erf_generalized, :fresnel_s, :fresnel_c, :beta_incomplete,
-        :beta_incomplete_regularized, :elliptic_f, :elliptic_e, :elliptic_eu,
-        :elliptic_pi, :elliptic_kc, :elliptic_ec, :jacobi_sn, :jacobi_cn,
-        :jacobi_dn, :jacobi_am, :hypergeometric, :struve_h, :struve_l)
-    @eval $fname(args...) = maxima_symbolic_call($fname, args...)
+    MaximaFunction(name)
+
+Opaque symbolic function returned for a valid Maxima function that has no
+explicit Julia mapping yet. It preserves the exact function name and supports
+roundtripping through `to_maxima` and `maxima_simplify`. `maxima_numeric` can
+evaluate it when Maxima knows a numerical value.
+"""
+struct MaximaFunction
+    name::Symbol
 end
 
-"""
-    maxima_notequal(lhs, rhs)
-    maxima_declare(var, property)
-    maxima_statement(text)
+struct MaximaIndexedFunction
+    name::Symbol
+    indices::Tuple
+end
 
-Helpers for assumptions passed to `integrate(...; assumptions=...)`.
-Use `maxima_notequal(n, -1)` for Maxima's `notequal(n,-1)` fact and
-`maxima_declare(n, :integer)` for declarations such as `declare(n,integer)`.
-`maxima_statement` is an escape hatch for expert Maxima context statements.
-"""
+(f::MaximaFunction)(args...) = maxima_symbolic_call(f, args...)
+(f::MaximaIndexedFunction)(args...) = maxima_symbolic_call(f, args...)
+Base.show(io::IO, f::MaximaFunction) = print(io, f.name)
+function Base.show(io::IO, f::MaximaIndexedFunction)
+    print(io, f.name, "[", join(f.indices, ","), "]")
+end
+
+# Maxima can return special functions that Symbolics does not define by default.
+# Keep them as symbolic calls so substitution and further algebra still work.
+for fname in MAXIMA_PLACEHOLDER_FUNCTIONS
+    doc = """
+        $(fname)(args...)
+
+    Symbolic placeholder for a special function returned by Maxima that
+    Symbolics.jl does not currently define as a standard symbolic function.
+    The expression supports substitution and conversion back to Maxima.
+    """
+    @eval begin
+        $fname(args...) = maxima_symbolic_call($fname, args...)
+        @doc $doc $fname
+    end
+end
+
 struct MaximaFact
     text::String
 end
@@ -61,8 +90,27 @@ struct MaximaStatement
     text::String
 end
 
+"""
+    maxima_notequal(lhs, rhs)
+
+Create a Maxima `notequal(lhs,rhs)` fact for an `assumptions` tuple.
+"""
 maxima_notequal(lhs, rhs) = MaximaFact("notequal($(to_maxima(lhs)),$(to_maxima(rhs)))")
+
+"""
+    maxima_declare(var, property)
+
+Create a Maxima declaration such as `declare(n,integer)` for an `assumptions`
+tuple. Pass the property as a symbol, for example `:integer`.
+"""
 maxima_declare(var, property::Symbol) = MaximaStatement("declare($(to_maxima(var)),$(property))")
+
+"""
+    maxima_statement(text)
+
+Create a raw Maxima context statement for an `assumptions` tuple. This is an
+expert escape hatch; `text` is sent directly to the fresh Maxima process.
+"""
 maxima_statement(text::AbstractString) = MaximaStatement(String(text))
 
 function maxima_symbolic_call(f, args...)
@@ -75,7 +123,9 @@ unwrap_for_symbolic_call(arg::Complex) = arg
 unwrap_for_symbolic_call(arg) = arg
 
 """
-    MaximaMethod(; command="maxima", timeout=5.0, validate=false, simplify_result=true)
+    MaximaMethod(; command="maxima", timeout=5.0, validate=false,
+                   simplify_result=true, expand_special_functions=true,
+                   assumptions=())
 
 Integration backend that delegates symbolic integration to a local Maxima process.
 The method is explicit by design:
@@ -90,22 +140,34 @@ integrate(f, x, a, b, MaximaMethod())
 - `timeout`: per-call timeout in seconds.
 - `validate`: validate indefinite integrals by differentiating the result.
 - `simplify_result`: wrap Maxima output in `ratsimp(...)` before parsing.
+- `expand_special_functions`: simplify special functions to elementary forms when
+  Maxima has an exact identity, for example `gamma_incomplete(3, 2)`.
+- `assumptions`: facts applied to every call made with this method. Per-call
+  `assumptions=...` override this tuple.
 """
 Base.@kwdef struct MaximaMethod <: AbstractIntegrationMethod
     command::String = "maxima"
     timeout::Float64 = 5.0
     validate::Bool = false
     simplify_result::Bool = true
+    expand_special_functions::Bool = true
+    assumptions::Tuple = ()
 end
 
 """
     MaximaError(message)
 
-Exception thrown when Maxima execution, conversion, or parsing fails.
+Exception thrown when Maxima execution, conversion, or parsing fails. The
+`kind` field distinguishes `:assumption`, `:timeout`, `:process`, `:syntax`,
+`:evaluation`, `:protocol`, `:serialization`, `:conversion`, `:unevaluated`,
+`:conditional`, and `:numeric` failures.
 """
 struct MaximaError <: Exception
     message::String
+    kind::Symbol
 end
+
+MaximaError(message::AbstractString) = MaximaError(String(message), :unknown)
 
 Base.showerror(io::IO, err::MaximaError) = print(io, err.message)
 
@@ -114,7 +176,14 @@ Base.showerror(io::IO, err::MaximaError) = print(io, err.message)
 
 Return whether a Maxima executable can be launched.
 """
-maxima_available(command::AbstractString="maxima") = success(Cmd(`$(command) --version`; ignorestatus=true))
+function maxima_available(command::AbstractString="maxima")
+    try
+        return success(Cmd(`$(command) --version`; ignorestatus=true))
+    catch err
+        err isa Base.IOError || rethrow()
+        return false
+    end
+end
 
 """
     maxima_call(expr; command="maxima", timeout=5)
@@ -125,7 +194,9 @@ long-lived session, but avoids shared-state bugs from assumptions and previous
 calculations.
 """
 function maxima_call(expr::AbstractString; command::AbstractString="maxima", timeout::Real=5)
+    timeout > 0 || throw(ArgumentError("`timeout` must be positive."))
     script = """
+    :lisp (progn (setq *query-io* (make-two-way-stream *standard-input* *standard-output*)) (values))
     display2d:false\$
     stringdisp:false\$
     printf(true, "$(RESULT_START)~%~a~%$(RESULT_END)~%", string($(expr)))\$
@@ -133,20 +204,37 @@ function maxima_call(expr::AbstractString; command::AbstractString="maxima", tim
     cmd = Cmd([String(command), "--very-quiet", "--batch-string=$(script)"])
     stdout_pipe = Pipe()
     stderr_pipe = Pipe()
-    proc = run(pipeline(cmd; stdout=stdout_pipe, stderr=stderr_pipe), wait=false)
+    proc = try
+        run(pipeline(cmd; stdout=stdout_pipe, stderr=stderr_pipe), wait=false)
+    catch err
+        if err isa Base.IOError
+            message = "Could not start Maxima executable `$(command)`. " *
+                "Install Maxima or pass `MaximaMethod(command=\"/path/to/maxima\")`."
+            throw(MaximaError(
+                message, :process))
+        end
+        rethrow()
+    end
     close(stdout_pipe.in)
     close(stderr_pipe.in)
+    stdout_reader = @async read(stdout_pipe, String)
+    stderr_reader = @async read(stderr_pipe, String)
 
     status = timedwait(() -> process_exited(proc), timeout)
     if status === :timed_out
         kill(proc)
-        throw(MaximaError("Maxima timed out after $(timeout) seconds while evaluating: $(expr)"))
+        wait(proc)
+        fetch(stdout_reader)
+        fetch(stderr_reader)
+        message = "Maxima timed out after $(timeout) seconds while evaluating: $(expr)"
+        throw(MaximaError(message, :timeout))
     end
 
-    stdout_text = read(stdout_pipe, String)
-    stderr_text = read(stderr_pipe, String)
+    stdout_text = fetch(stdout_reader)
+    stderr_text = fetch(stderr_reader)
     if !success(proc)
-        throw(MaximaError("Maxima failed while evaluating: $(expr)\n$(stderr_text)$(stdout_text)"))
+        message = "Maxima failed while evaluating: $(expr)\n$(stderr_text)$(stdout_text)"
+        throw(MaximaError(message, :process))
     end
 
     return extract_result(stdout_text, expr)
@@ -157,12 +245,32 @@ function extract_result(output::AbstractString, expr::AbstractString)
     matches = collect(eachmatch(pattern, output))
     if isempty(matches)
         if maxima_requested_assumption(output)
-            throw(MaximaError("Maxima did not produce a result; additional assumptions may be required while evaluating: $(expr)\n$(output)"))
+            questions = maxima_questions(output)
+            detail = isempty(questions) ? "" : "\nMaxima asked:\n  " * join(questions, "\n  ")
+            message = "Maxima requires additional assumptions while evaluating: $(expr)$(detail)"
+            throw(MaximaError(message, :assumption))
         end
-        throw(MaximaError("Could not parse Maxima output for: $(expr)\n$(output)"))
+        if occursin("incorrect syntax", output)
+            message = "Maxima rejected the generated syntax for: $(expr)\n$(output)"
+            throw(MaximaError(message, :syntax))
+        end
+        if occursin(" -- an error", output)
+            throw(MaximaError("Maxima failed while evaluating: $(expr)\n$(output)", :evaluation))
+        end
+        message = "Could not find the result marker in Maxima output for: $(expr)\n$(output)"
+        throw(MaximaError(message, :protocol))
     end
     match_result = last(matches)
     return strip(match_result.captures[1])
+end
+
+function maxima_questions(output::AbstractString)
+    questions = String[]
+    for line in eachline(IOBuffer(output))
+        text = strip(line)
+        startswith(text, "Is ") && endswith(text, "?") && push!(questions, text)
+    end
+    return unique(questions)
 end
 
 function maxima_requested_assumption(output::AbstractString)
@@ -184,14 +292,18 @@ to_maxima(expr::Symbolics.Num) = to_maxima(Symbolics.unwrap(expr))
 to_maxima(expr::Integer) = string(expr)
 function to_maxima(expr::AbstractFloat)
     isinf(expr) && return expr > 0 ? "inf" : "minf"
-    isnan(expr) && throw(MaximaError("Cannot serialize NaN to Maxima."))
+    isnan(expr) && throw(MaximaError("Cannot serialize NaN to Maxima.", :serialization))
     return string(expr)
 end
 to_maxima(expr::Rational) = string(numerator(expr), "/", denominator(expr))
+to_maxima(expr::AbstractVector) = string("[", join(to_maxima.(expr), ","), "]")
+to_maxima(expr::Tuple) = string("[", join(to_maxima.(expr), ","), "]")
+to_maxima(expr::Bool) = string(expr)
 to_maxima(expr::Irrational{:π}) = "%pi"
 to_maxima(expr::Irrational{:ℯ}) = "%e"
 to_maxima(expr::Irrational{:γ}) = "%gamma"
 to_maxima(expr::Irrational{:φ}) = "%phi"
+to_maxima(expr::Irrational{:catalan}) = "%catalan"
 to_maxima(expr::Complex) = "($(to_maxima(real(expr)))+$(to_maxima(imag(expr)))*%i)"
 
 function to_maxima(expr)
@@ -199,6 +311,13 @@ function to_maxima(expr)
         op = SymbolicUtils.operation(expr)
         args = SymbolicUtils.arguments(expr)
         return maxima_call_syntax(op, args)
+    end
+
+    try
+        literal = Symbolics.value(Symbolics.wrap(expr))
+        literal isa AbstractVector && return to_maxima(literal)
+    catch
+        # Ordinary symbolic variables do not have a concrete value.
     end
 
     text = string(expr)
@@ -209,6 +328,7 @@ function to_maxima(expr)
     text == "ℯ" && return "%e"
     text == "γ" && return "%gamma"
     text == "φ" && return "%phi"
+    text == "catalan" && return "%catalan"
     text == "im" && return "%i"
     text == "Inf" && return "inf"
     text == "-Inf" && return "minf"
@@ -217,6 +337,8 @@ end
 
 function maxima_call_syntax(op, args)
     op === identity && return to_maxima(args[1])
+    op === complex && length(args) == 2 &&
+        return "($(to_maxima(args[1]))+$(to_maxima(args[2]))*%i)"
     op === (+) && return join_parenthesized(args, "+")
     op === (*) && return join_parenthesized(args, "*")
     op === (-) && return length(args) == 1 ? "(-$(to_maxima(args[1])))" :
@@ -229,12 +351,36 @@ function maxima_call_syntax(op, args)
     op === (>=) && return "($(to_maxima(args[1]))>=$(to_maxima(args[2])))"
     op === (==) && return "($(to_maxima(args[1]))=$(to_maxima(args[2])))"
     op === (!=) && return "notequal($(to_maxima(args[1])),$(to_maxima(args[2])))"
+    op isa MaximaFunction && return string(op.name, "(", join(to_maxima.(args), ","), ")")
+    if op isa MaximaIndexedFunction
+        indices = join(to_maxima.(op.indices), ",")
+        return string(op.name, "[", indices, "](", join(to_maxima.(args), ","), ")")
+    end
+
+    indexed = maxima_indexed_call_syntax(op, args)
+    indexed === nothing || return indexed
 
     name = maxima_function_name(op)
     name === nothing &&
-        throw(MaximaError("Cannot serialize Symbolics operation `$(op)` to Maxima."))
+        throw(MaximaError(
+            "Cannot serialize Symbolics operation `$(op)` to Maxima.", :serialization))
 
     return string(name, "(", join(to_maxima.(args), ","), ")")
+end
+
+function maxima_indexed_call_syntax(op, args)
+    if op === polygamma && length(args) == 2
+        return "psi[$(to_maxima(args[1]))]($(to_maxima(args[2])))"
+    elseif op === polylog && length(args) == 2
+        return "li[$(to_maxima(args[1]))]($(to_maxima(args[2])))"
+    elseif op === assoc_legendre_p && length(args) == 3
+        indices = join(to_maxima.(args[1:2]), ",")
+        return "assoc_legendre_p[$(indices)]($(to_maxima(args[3])))"
+    elseif op === assoc_legendre_q && length(args) == 3
+        indices = join(to_maxima.(args[1:2]), ",")
+        return "assoc_legendre_q[$(indices)]($(to_maxima(args[3])))"
+    end
+    return nothing
 end
 
 join_parenthesized(args, sep) = string("(", join(to_maxima.(args), sep), ")")
@@ -268,6 +414,29 @@ function maxima_function_name(op)
     op === log && return "log"
     op === sqrt && return "sqrt"
     op === abs && return "abs"
+    op === sign && return "signum"
+    op === floor && return "floor"
+    op === ceil && return "ceiling"
+    op === min && return "min"
+    op === max && return "max"
+    op === conj && return "conjugate"
+    op === real && return "realpart"
+    op === imag && return "imagpart"
+    op === erf && return "erf"
+    op === erfc && return "erfc"
+    op === erfi && return "erfi"
+    op === gamma && return "gamma"
+    op === loggamma && return "log_gamma"
+    op === beta && return "beta"
+    op === besselj && return "bessel_j"
+    op === bessely && return "bessel_y"
+    op === besseli && return "bessel_i"
+    op === besselk && return "bessel_k"
+    op === airyai && return "airy_ai"
+    op === airybi && return "airy_bi"
+    for name in MAXIMA_PLAIN_PLACEHOLDERS
+        op === getfield(@__MODULE__, name) && return String(name)
+    end
     return nothing
 end
 
@@ -279,25 +448,46 @@ the symbolic variables that may appear in `text`.
 """
 function from_maxima(text::AbstractString, vars)
     occursin("integrate(", text) &&
-        throw(MaximaError("Maxima returned an unevaluated integral: $(text)"))
+        throw(MaximaError("Maxima returned an unevaluated integral: $(text)", :unevaluated))
     occursin("if ", text) &&
-        throw(MaximaError("Maxima returned a conditional expression that is not parsed yet: $(text)"))
+        throw(MaximaError(
+            "Maxima returned a conditional expression that is not parsed yet: $(text)",
+            :conditional))
 
-    parsed = Meta.parse(maxima_to_julia_syntax(text))
+    normalized = maxima_to_julia_syntax(text)
+    parsed = try
+        Meta.parse(normalized)
+    catch err
+        err isa Base.Meta.ParseError || rethrow()
+        throw(MaximaError(
+            "Could not parse Maxima result `$(text)`. Normalized form: `$(normalized)`.",
+            :conversion))
+    end
     env = variable_environment(vars)
     return Symbolics.wrap(eval_parsed_maxima(parsed, env))
 end
 
 function maxima_to_julia_syntax(text::AbstractString)
-    normalized = replace(text,
-        "%pi" => "pi",
-        "%i" => "im",
-        "minf" => "-Inf",
-        "inf" => "Inf",
-        "%e" => "__maxima_e",
-        "%gamma" => "__maxima_eulergamma",
-        "%phi" => "__maxima_golden")
+    normalized = replace_maxima_bigfloats(text)
+    normalized = replace(normalized,
+        r"%f(?=\[)" => "maxima_hypergeometric_indexed",
+        r"%pi(?![A-Za-z0-9_])" => "pi",
+        r"%i(?![A-Za-z0-9_])" => "im",
+        r"(?<![A-Za-z0-9_])minf(?![A-Za-z0-9_])" => "-Inf",
+        r"(?<![A-Za-z0-9_])inf(?![A-Za-z0-9_])" => "Inf",
+        r"%e(?![A-Za-z0-9_])" => "__maxima_e",
+        r"%gamma(?![A-Za-z0-9_])" => "__maxima_eulergamma",
+        r"%phi(?![A-Za-z0-9_])" => "__maxima_golden",
+        r"%catalan(?![A-Za-z0-9_])" => "__maxima_catalan")
     return normalized
+end
+
+function replace_maxima_bigfloats(text::AbstractString)
+    pattern = r"(?<![A-Za-z0-9_.])(?:\d+(?:\.\d*)?|\.\d+)[bB][+-]?\d+"
+    return replace(text, pattern => value -> begin
+        decimal = replace(String(value), r"[bB]" => "e")
+        "__maxima_bigfloat__(\"$(decimal)\")"
+    end)
 end
 
 function variable_environment(vars)
@@ -312,6 +502,7 @@ end
 function eval_parsed_maxima(ex, env::Dict{Symbol, Any})
     ex isa Integer && return ex
     ex isa AbstractFloat && return ex
+    ex isa String && return ex
     ex isa Symbol && return symbol_value(ex, env)
 
     if ex isa Expr && ex.head === :call
@@ -321,7 +512,7 @@ function eval_parsed_maxima(ex, env::Dict{Symbol, Any})
         return Any[eval_parsed_maxima(arg, env) for arg in ex.args]
     end
 
-    throw(MaximaError("Unsupported parsed Maxima expression: $(ex)"))
+    throw(MaximaError("Unsupported parsed Maxima expression: $(ex)", :conversion))
 end
 
 function symbol_value(sym::Symbol, env::Dict{Symbol, Any})
@@ -331,14 +522,25 @@ function symbol_value(sym::Symbol, env::Dict{Symbol, Any})
     sym === :__maxima_e && return Symbolics.Num(ℯ)
     sym === :__maxima_eulergamma && return Symbolics.Num(Base.MathConstants.eulergamma)
     sym === :__maxima_golden && return Symbolics.Num(Base.MathConstants.golden)
-    throw(MaximaError("Maxima returned unknown symbol `$(sym)`. Pass it as a Symbolics variable."))
+    sym === :__maxima_catalan && return Symbolics.Num(Base.MathConstants.catalan)
+    sym === :Inf && return Inf
+    sym === :true && return true
+    sym === :false && return false
+    throw(MaximaError(
+        "Maxima returned unknown symbol `$(sym)`. Pass it as a Symbolics variable.",
+        :conversion))
 end
 
 function eval_call(args, env)
     op = args[1]
 
+    if op isa Expr && op.head === :ref
+        return eval_indexed_call(op, args[2:end], env)
+    end
+
     if op === :^ && args[2] === :__maxima_e
-        return exp(eval_parsed_maxima(args[3], env))
+        exponent = eval_parsed_maxima(args[3], env)
+        return symbolic_exponential(exponent)
     end
 
     values = Any[eval_parsed_maxima(arg, env) for arg in args[2:end]]
@@ -349,8 +551,36 @@ function eval_call(args, env)
     op === :/ && return rational_or_divide(values[1], values[2])
     op === :^ && return values[1]^values[2]
 
+    return call_parsed_function(op, values)
+end
+
+symbolic_exponential(exponent::Symbolics.Num) = exp(exponent)
+symbolic_exponential(exponent::Real) = exp(Symbolics.Num(exponent))
+symbolic_exponential(exponent) = maxima_symbolic_call(exp, exponent)
+
+function eval_indexed_call(op::Expr, args, env)
+    name = op.args[1]
+    indices = Any[eval_parsed_maxima(index, env) for index in op.args[2:end]]
+    values = Any[eval_parsed_maxima(arg, env) for arg in args]
+
+    name === :psi && return call_parsed_function(:polygamma, vcat(indices, values))
+    name === :li && return call_parsed_function(:polylog, vcat(indices, values))
+    name === :assoc_legendre_p &&
+        return call_parsed_function(:assoc_legendre_p, vcat(indices, values))
+    name === :assoc_legendre_q &&
+        return call_parsed_function(:assoc_legendre_q, vcat(indices, values))
+    if name === :maxima_hypergeometric_indexed
+        length(values) == 3 ||
+            throw(MaximaError(
+                "Unsupported indexed Maxima hypergeometric expression `$(op)`.", :conversion))
+        return call_parsed_function(:hypergeometric, values)
+    end
+    return MaximaIndexedFunction(name, Tuple(indices))(values...)
+end
+
+function call_parsed_function(op::Symbol, values)
     fn = julia_function(op)
-    fn === nothing && throw(MaximaError("Unsupported Maxima function `$(op)`."))
+    fn === nothing && return MaximaFunction(op)(values...)
     try
         return fn(values...)
     catch err
@@ -394,10 +624,21 @@ function julia_function(op::Symbol)
     op === :log && return log
     op === :sqrt && return sqrt
     op === :abs && return abs
+    op === :signum && return sign
+    op === :floor && return floor
+    op === :ceiling && return ceil
+    op === :min && return min
+    op === :max && return max
+    op === :conjugate && return conj
+    op === :realpart && return real
+    op === :imagpart && return imag
+    op === :__maxima_bigfloat__ && return parse_maxima_bigfloat
     op === :erf && return erf
     op === :erfc && return erfc
     op === :erfi && return erfi
     op === :gamma && return gamma
+    op === :log_gamma && return loggamma
+    op === :polygamma && return polygamma
     op === :beta && return beta
     op === :bessel_j && return besselj
     op === :bessel_y && return bessely
@@ -405,52 +646,16 @@ function julia_function(op::Symbol)
     op === :bessel_k && return besselk
     op === :airy_ai && return airyai
     op === :airy_bi && return airybi
-    op === :gamma_incomplete && return gamma_incomplete
-    op === :gamma_incomplete_lower && return gamma_incomplete_lower
-    op === :gamma_incomplete_regularized && return gamma_incomplete_regularized
-    op === :gamma_incomplete_generalized && return gamma_incomplete_generalized
-    op === :expintegral_e && return expintegral_e
-    op === :expintegral_e1 && return expintegral_e1
-    op === :expintegral_ei && return expintegral_ei
-    op === :expintegral_li && return expintegral_li
-    op === :expintegral_si && return expintegral_si
-    op === :expintegral_ci && return expintegral_ci
-    op === :expintegral_shi && return expintegral_shi
-    op === :expintegral_chi && return expintegral_chi
-    op === :sin_integral && return sin_integral
-    op === :cos_integral && return cos_integral
-    op === :erf_generalized && return erf_generalized
-    op === :fresnel_s && return fresnel_s
-    op === :fresnel_c && return fresnel_c
-    op === :beta_incomplete && return beta_incomplete
-    op === :beta_incomplete_regularized && return beta_incomplete_regularized
-    op === :elliptic_f && return elliptic_f
-    op === :elliptic_e && return elliptic_e
-    op === :elliptic_eu && return elliptic_eu
-    op === :elliptic_pi && return elliptic_pi
-    op === :elliptic_kc && return elliptic_kc
-    op === :elliptic_ec && return elliptic_ec
-    op === :jacobi_sn && return jacobi_sn
-    op === :jacobi_cn && return jacobi_cn
-    op === :jacobi_dn && return jacobi_dn
-    op === :jacobi_am && return jacobi_am
-    op === :hypergeometric && return hypergeometric
-    op === :struve_h && return struve_h
-    op === :struve_l && return struve_l
+    op in MAXIMA_PLACEHOLDER_FUNCTIONS && return getfield(@__MODULE__, op)
     return nothing
 end
 
+parse_maxima_bigfloat(text::AbstractString) = parse(BigFloat, text)
+
 function supports_symbolic_fallback(op::Symbol)
-    return op in (:erf, :erfc, :erfi, :gamma, :beta, :bessel_j, :bessel_y,
-        :bessel_i, :bessel_k, :airy_ai, :airy_bi, :gamma_incomplete,
-        :gamma_incomplete_lower, :gamma_incomplete_regularized,
-        :gamma_incomplete_generalized, :expintegral_e, :expintegral_e1,
-        :expintegral_ei, :expintegral_li, :expintegral_si, :expintegral_ci,
-        :expintegral_shi, :expintegral_chi, :sin_integral, :cos_integral,
-        :erf_generalized, :fresnel_s, :fresnel_c, :beta_incomplete,
-        :beta_incomplete_regularized, :elliptic_f, :elliptic_e, :elliptic_eu,
-        :elliptic_pi, :elliptic_kc, :elliptic_ec, :jacobi_sn, :jacobi_cn,
-        :jacobi_dn, :jacobi_am, :hypergeometric, :struve_h, :struve_l)
+    native = (:erf, :erfc, :erfi, :gamma, :log_gamma, :polygamma, :beta,
+        :bessel_j, :bessel_y, :bessel_i, :bessel_k, :airy_ai, :airy_bi)
+    return op in native || op in MAXIMA_PLACEHOLDER_FUNCTIONS
 end
 
 """
@@ -475,19 +680,20 @@ bridge.
 """
 function integrate(f::Symbolics.Num, x::Symbolics.Num, method::MaximaMethod;
         validate=method.validate, kwargs...)
-    result = maxima_integral(f, x, nothing, nothing, method; validate=validate, kwargs...)
+    result = maxima_integral(f, x, nothing, nothing, method; kwargs...)
     validate && validate_indefinite(f, x, result)
     return result
 end
 
 function integrate(f::Symbolics.Num, x::Symbolics.Num, a, b, method::MaximaMethod;
         validate=method.validate, kwargs...)
-    result = maxima_integral(f, x, a, b, method; validate=validate, kwargs...)
+    result = maxima_integral(f, x, a, b, method; kwargs...)
     return result
 end
 
-function maxima_integral(f, x, a, b, method::MaximaMethod; assumptions=(),
-        timeout=method.timeout, validate=method.validate, simplify_result=method.simplify_result)
+function maxima_integral(f, x, a, b, method::MaximaMethod; assumptions=method.assumptions,
+        timeout=method.timeout, simplify_result=method.simplify_result,
+        expand_special_functions=method.expand_special_functions)
     integrand = to_maxima(f)
     variable = to_maxima(x)
     command = if a === nothing && b === nothing
@@ -496,11 +702,134 @@ function maxima_integral(f, x, a, b, method::MaximaMethod; assumptions=(),
         "integrate($(integrand),$(variable),$(to_maxima(a)),$(to_maxima(b)))"
     end
 
-    simplify_result && (command = "ratsimp($(command))")
-    command = wrap_assumptions(command, assumptions)
+    command = prepare_maxima_result(command;
+        simplify_result=simplify_result,
+        expand_special_functions=expand_special_functions)
+    variables = collect_variables(f, x, a, b, assumptions)
+    parameters = filter(var -> !isequal(var, x), collect_variables(f, a, b))
 
-    raw = maxima_call(command; command=method.command, timeout=timeout)
-    return from_maxima(raw, collect_variables(f, x, a, b, assumptions))
+    raw = run_maxima(command, method, assumptions, parameters; timeout=timeout)
+    return from_maxima(raw, variables)
+end
+
+function prepare_maxima_result(command::AbstractString;
+        simplify_result::Bool, expand_special_functions::Bool)
+    if expand_special_functions
+        command = "ev($(command),gamma_expand=true,beta_expand=true,besselexpand=true)"
+    end
+    simplify_result && (command = "ratsimp($(command))")
+    return command
+end
+
+function run_maxima(command::AbstractString, method::MaximaMethod, assumptions, parameters;
+        timeout=method.timeout)
+    contextual_command = wrap_assumptions(command, assumptions)
+    try
+        return maxima_call(contextual_command; command=method.command, timeout=timeout)
+    catch err
+        if err isa MaximaError && err.kind === :assumption
+            throw(add_assumption_guidance(err, parameters))
+        end
+        rethrow()
+    end
+end
+
+function add_assumption_guidance(err::MaximaError, parameters)
+    names = sort!(unique(string.(parameters)))
+    isempty(names) && return err
+
+    parameter_text = join(names, ", ")
+    guidance = "\nUnknown parameter(s): $(parameter_text)."
+    if length(names) == 1
+        name = only(names)
+        guidance *= """
+
+Retry with the mathematically valid branch, for example:
+  assumptions=($(name) > 0,)
+  assumptions=($(name) < 0,)
+  assumptions=(maxima_notequal($(name), 0),)
+Do not choose an assumption solely to force a result; improper integrals can diverge on other branches."""
+    else
+        guidance *= "\nPass the required sign, nonzero, or integer facts " *
+            "through `assumptions=(...)`."
+    end
+    return MaximaError(err.message * guidance, :assumption)
+end
+
+"""
+    maxima_simplify(expr; method=MaximaMethod(), assumptions=method.assumptions,
+                    expand_special_functions=method.expand_special_functions)
+
+Simplify a Symbolics expression with Maxima and parse the exact result back into
+Julia. Exact special-function identities are enabled by default.
+"""
+function maxima_simplify(expr; method::MaximaMethod=MaximaMethod(),
+        assumptions=method.assumptions, timeout=method.timeout,
+        expand_special_functions=method.expand_special_functions)
+    command = prepare_maxima_result(to_maxima(expr);
+        simplify_result=true,
+        expand_special_functions=expand_special_functions)
+    variables = collect_variables(expr, assumptions)
+    raw = run_maxima(command, method, assumptions, collect_variables(expr); timeout=timeout)
+    return from_maxima(raw, variables)
+end
+
+"""
+    maxima_numeric(expr; method=MaximaMethod(), assumptions=method.assumptions,
+                   digits=16)
+
+Numerically evaluate a constant Symbolics expression with Maxima. Substitute all
+free variables first. Up to 16 decimal digits returns a Julia `Float64` or
+`ComplexF64`; larger values of `digits` return `BigFloat` or
+`Complex{BigFloat}` values.
+"""
+function maxima_numeric(expr; method::MaximaMethod=MaximaMethod(),
+        assumptions=method.assumptions, timeout=method.timeout, digits::Integer=16)
+    digits >= 2 || throw(ArgumentError("`digits` must be at least 2."))
+    command = if digits <= 16
+        "ev($(to_maxima(expr)),nouns,numer)"
+    else
+        "block([fpprec:$(digits)],bfloat(ev($(to_maxima(expr)),nouns)))"
+    end
+    variables = collect_variables(expr, assumptions)
+    raw = run_maxima(command, method, assumptions, collect_variables(expr); timeout=timeout)
+    if digits <= 16
+        value = numeric_value(from_maxima(raw, variables), expr)
+        return convert_numeric(value, Float64)
+    end
+    bits = ceil(Int, digits * log2(10)) + 8
+    return setprecision(BigFloat, bits) do
+        value = numeric_value(from_maxima(raw, variables), expr)
+        convert_numeric(value, BigFloat)
+    end
+end
+
+function numeric_value(value::Symbolics.Num, original)
+    variables = Symbolics.get_variables(value)
+    isempty(variables) || throw(MaximaError(
+        "Maxima could not reduce `$(original)` to a number. Substitute all free variables first.",
+        :numeric))
+
+    literal = Symbolics.value(value)
+    literal isa Number && return literal
+    throw(MaximaError(
+        "Maxima could not reduce `$(original)` to a numeric value; it returned `$(value)`.",
+        :numeric))
+end
+
+function numeric_value(value::Complex, original)
+    real_value = numeric_value(real(value), original)
+    imag_value = numeric_value(imag(value), original)
+    return complex(real_value, imag_value)
+end
+
+numeric_value(value::Number, original) = value
+numeric_value(value, original) = throw(MaximaError(
+    "Maxima could not reduce `$(original)` to a number; it returned `$(value)`.", :numeric))
+
+convert_numeric(value::Real, ::Type{T}) where {T <: AbstractFloat} = T(value)
+function convert_numeric(value::Complex, ::Type{T}) where {T <: AbstractFloat}
+    return complex(T(real(value)), T(imag(value)))
 end
 
 function wrap_assumptions(command::AbstractString, assumptions)
@@ -514,7 +843,7 @@ function wrap_assumptions(command::AbstractString, assumptions)
         elseif context isa MaximaStatement
             push!(statements, context.text)
         else
-            throw(MaximaError("Unsupported Maxima assumption context: $(context)"))
+            throw(MaximaError("Unsupported Maxima assumption context: $(context)", :serialization))
         end
     end
 
@@ -553,6 +882,55 @@ function validate_indefinite(f, x, result)
 
     # Symbolic simplification is intentionally conservative; warn instead of rejecting.
     @warn "Could not symbolically validate Maxima antiderivative" residual
+    return nothing
+end
+
+"""
+    maxima_status([method=MaximaMethod()]; io=stdout) -> Bool
+
+Print the backend and Maxima versions and return whether Maxima is available.
+"""
+function maxima_status(method::MaximaMethod=MaximaMethod(); io::IO=stdout)
+    if !maxima_available(method.command)
+        println(io, "SymbolicIntegrationMaxima ", Base.pkgversion(@__MODULE__))
+        println(io, "Maxima executable not found: ", method.command)
+        return false
+    end
+
+    version = strip(read(Cmd([method.command, "--version"]), String))
+    println(io, "SymbolicIntegrationMaxima ", Base.pkgversion(@__MODULE__))
+    println(io, version)
+    println(io, "command: ", method.command)
+    return true
+end
+
+"""
+    maxima_help([io=stdout])
+
+Print a compact REPL guide. Julia's help mode also provides detailed entries:
+`?MaximaMethod`, `?maxima_integrate`, `?maxima_simplify`, and `?maxima_numeric`.
+"""
+function maxima_help(io::IO=stdout)
+    print(io, """
+SymbolicIntegrationMaxima quick help
+
+  M = MaximaMethod(timeout=10)
+  integrate(f, x, M)                         # indefinite
+  integrate(f, x, a, b, M)                   # definite
+  integrate(f, x, 0, Inf, M; assumptions=(a > 0,))
+
+  maxima_simplify(expr)                       # exact simplification
+  maxima_numeric(expr)                        # Float64 / ComplexF64
+  maxima_status(M)                            # installation check
+
+Reusable assumptions:
+
+  M = MaximaMethod(assumptions=(a > 0, maxima_declare(n, :integer)))
+  maxima_notequal(n, -1)                      # notequal(n,-1)
+  maxima_statement("domain:complex")          # expert Maxima context
+
+Use `?MaximaMethod` or `?maxima_numeric` for full docstrings.
+""")
     return nothing
 end
 

--- a/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
+++ b/lib/SymbolicIntegrationMaxima/src/SymbolicIntegrationMaxima.jl
@@ -24,6 +24,9 @@ export assoc_legendre_p, assoc_legendre_q
 
 const RESULT_START = "__SYMBOLIC_INTEGRATION_MAXIMA_RESULT_START__"
 const RESULT_END = "__SYMBOLIC_INTEGRATION_MAXIMA_RESULT_END__"
+const QUESTION_START = "__SYMBOLIC_INTEGRATION_MAXIMA_QUESTION_START__"
+const QUESTION_END = "__SYMBOLIC_INTEGRATION_MAXIMA_QUESTION_END__"
+const ASSUMPTION_ABORT = "__SYMBOLIC_INTEGRATION_MAXIMA_ASSUMPTION_REQUIRED__"
 
 const MAXIMA_PLACEHOLDER_FUNCTIONS = (
     :gamma_incomplete, :gamma_incomplete_lower, :gamma_incomplete_regularized,
@@ -195,8 +198,24 @@ calculations.
 """
 function maxima_call(expr::AbstractString; command::AbstractString="maxima", timeout::Real=5)
     timeout > 0 || throw(ArgumentError("`timeout` must be positive."))
+    # A batch process must report assumption questions instead of reading stdin.
+    retrieve_interceptor = join((
+        ":lisp (progn ",
+        "(setf (symbol-function 'retrieve) ",
+        "(lambda (msg flag) ",
+        "(format *standard-output* \"$(QUESTION_START)~%\") ",
+        "(cond ((null msg) (format-prompt *standard-output* \"\")) ",
+        "((atom msg) (format-prompt *standard-output* \"~A\" msg)) ",
+        "((eq flag t) (format-prompt *standard-output* \"~{~A~}\" (cdr msg))) ",
+        "(t (format-prompt *standard-output* \"~M\" msg))) ",
+        "(mterpri *standard-output*) ",
+        "(format *standard-output* \"$(QUESTION_END)~%\") ",
+        "(finish-output *standard-output*) ",
+        "(merror \"$(ASSUMPTION_ABORT)\"))) ",
+        "(values))",
+    ))
     script = """
-    :lisp (progn (setq *query-io* (make-two-way-stream *standard-input* *standard-output*)) (values))
+    $(retrieve_interceptor)
     display2d:false\$
     stringdisp:false\$
     printf(true, "$(RESULT_START)~%~a~%$(RESULT_END)~%", string($(expr)))\$
@@ -224,14 +243,18 @@ function maxima_call(expr::AbstractString; command::AbstractString="maxima", tim
     if status === :timed_out
         kill(proc)
         wait(proc)
-        fetch(stdout_reader)
+        stdout_text = fetch(stdout_reader)
         fetch(stderr_reader)
+        maxima_intercepted_assumption(stdout_text) &&
+            throw_assumption_error(stdout_text, expr)
         message = "Maxima timed out after $(timeout) seconds while evaluating: $(expr)"
         throw(MaximaError(message, :timeout))
     end
 
     stdout_text = fetch(stdout_reader)
     stderr_text = fetch(stderr_reader)
+    maxima_intercepted_assumption(stdout_text) &&
+        throw_assumption_error(stdout_text, expr)
     if !success(proc)
         message = "Maxima failed while evaluating: $(expr)\n$(stderr_text)$(stdout_text)"
         throw(MaximaError(message, :process))
@@ -244,12 +267,7 @@ function extract_result(output::AbstractString, expr::AbstractString)
     pattern = Regex("^$(RESULT_START)\\s*\\n(.*?)\\n$(RESULT_END)\\s*\$", "ms")
     matches = collect(eachmatch(pattern, output))
     if isempty(matches)
-        if maxima_requested_assumption(output)
-            questions = maxima_questions(output)
-            detail = isempty(questions) ? "" : "\nMaxima asked:\n  " * join(questions, "\n  ")
-            message = "Maxima requires additional assumptions while evaluating: $(expr)$(detail)"
-            throw(MaximaError(message, :assumption))
-        end
+        maxima_requested_assumption(output) && throw_assumption_error(output, expr)
         if occursin("incorrect syntax", output)
             message = "Maxima rejected the generated syntax for: $(expr)\n$(output)"
             throw(MaximaError(message, :syntax))
@@ -264,8 +282,22 @@ function extract_result(output::AbstractString, expr::AbstractString)
     return strip(match_result.captures[1])
 end
 
+function throw_assumption_error(output::AbstractString, expr::AbstractString)
+    questions = maxima_questions(output)
+    detail = isempty(questions) ? "" : "\nMaxima asked:\n  " * join(questions, "\n  ")
+    message = "Maxima requires additional assumptions while evaluating: $(expr)$(detail)"
+    throw(MaximaError(message, :assumption))
+end
+
 function maxima_questions(output::AbstractString)
     questions = String[]
+    pattern = Regex("$(QUESTION_START)\\s*\\n(.*?)\\n$(QUESTION_END)", "ms")
+    for match_result in eachmatch(pattern, output)
+        text = join(split(strip(match_result.captures[1])), " ")
+        isempty(text) || push!(questions, text)
+    end
+
+    isempty(questions) || return unique(questions)
     for line in eachline(IOBuffer(output))
         text = strip(line)
         startswith(text, "Is ") && endswith(text, "?") && push!(questions, text)
@@ -274,12 +306,17 @@ function maxima_questions(output::AbstractString)
 end
 
 function maxima_requested_assumption(output::AbstractString)
-    return occursin("Acceptable answers are", output) ||
+    return maxima_intercepted_assumption(output) ||
+        occursin("Acceptable answers are", output) ||
         occursin("RETRIEVE: End of file encountered", output) ||
         (occursin("printf(true", output) &&
          occursin(RESULT_START, output) &&
          !occursin("incorrect syntax", output) &&
          !occursin(" -- an error", output))
+end
+
+function maxima_intercepted_assumption(output::AbstractString)
+    return occursin(QUESTION_START, output) || occursin(ASSUMPTION_ABORT, output)
 end
 
 """

--- a/lib/SymbolicIntegrationMaxima/test/runtests.jl
+++ b/lib/SymbolicIntegrationMaxima/test/runtests.jl
@@ -241,6 +241,8 @@ end
             @test isequal(Symbolics.simplify(integrate(sin(x) / x, x, 0, Inf, method) - π / 2), 0)
             @test isequal(Symbolics.simplify(integrate(sin(π * x / L)^2, x, 0, L, method; assumptions=(L > 0,)) - L / 2), 0)
             @test isequal(Symbolics.simplify(integrate(exp(-a * x), x, 0, Inf, method; assumptions=(a > 0,)) - 1 / a), 0)
+            @test isequal(integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, method; assumptions=(C > 0,)), 0)
+            @test_throws MaximaError integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, method)
             atan_form = integrate(1 / (a + b * x^2), x, method; assumptions=(a > 0, b > 0))
             @test isequal(Symbolics.simplify(atan_form - atan(sqrt(b) * x / sqrt(a)) / (sqrt(a) * sqrt(b))), 0)
         end

--- a/lib/SymbolicIntegrationMaxima/test/runtests.jl
+++ b/lib/SymbolicIntegrationMaxima/test/runtests.jl
@@ -240,6 +240,20 @@ end
             @test assumption_error isa MaximaError
             @test assumption_error.kind === :assumption
             @test occursin("Is ", sprint(showerror, assumption_error))
+            marked_question = """
+            $(SymbolicIntegrationMaxima.QUESTION_START)
+            Is C positive, negative or zero?
+            $(SymbolicIntegrationMaxima.QUESTION_END)
+            $(SymbolicIntegrationMaxima.ASSUMPTION_ABORT)
+            """
+            marked_error = try
+                SymbolicIntegrationMaxima.extract_result(marked_question, "integrate(f,x)")
+            catch err
+                err
+            end
+            @test marked_error isa MaximaError
+            @test marked_error.kind === :assumption
+            @test occursin("Is C positive, negative or zero?", sprint(showerror, marked_error))
             @test isequal(Symbolics.simplify(from_maxima("sec(x)", [x]) - sec(x)), 0)
             @test isequal(Symbolics.simplify(from_maxima("asinh(x)", [x]) - asinh(x)), 0)
             @test occursin("γ", string(from_maxima("%gamma", [])))

--- a/lib/SymbolicIntegrationMaxima/test/runtests.jl
+++ b/lib/SymbolicIntegrationMaxima/test/runtests.jl
@@ -92,12 +92,12 @@ end
 
 function is_unevaluated_integral_error(err)
     err isa MaximaError || return false
-    return startswith(sprint(showerror, err), "Maxima returned an unevaluated integral:")
+    return err.kind === :unevaluated
 end
 
 function is_assumption_needed_error(err)
     err isa MaximaError || return false
-    return startswith(sprint(showerror, err), "Maxima did not produce a result; additional assumptions may be required")
+    return err.kind === :assumption
 end
 
 function exception_summary(err)
@@ -179,6 +179,18 @@ end
     if TEST_GROUP == "all" || TEST_GROUP == "basic"
         @testset "Maxima availability" begin
             @test maxima_available()
+            @test !maxima_available("maxima-command-that-does-not-exist")
+            launch_error = try
+                maxima_call("1 + 1"; command="maxima-command-that-does-not-exist")
+            catch err
+                err
+            end
+            @test launch_error isa MaximaError
+            @test launch_error.kind === :process
+
+            status_output = IOBuffer()
+            @test maxima_status(MaximaMethod(); io=status_output)
+            @test occursin("Maxima", String(take!(status_output)))
         end
 
         @testset "Symbolics to Maxima serialization" begin
@@ -189,6 +201,7 @@ end
             @test to_maxima(x > 0) == "(0<x)"
             @test to_maxima(ℯ) == "%e"
             @test to_maxima(π) == "%pi"
+            @test to_maxima(Base.MathConstants.catalan) == "%catalan"
             pi_product_text = to_maxima(π * x)
             @test occursin("%pi", pi_product_text)
             @test occursin("x", pi_product_text)
@@ -196,22 +209,54 @@ end
             @test all(f -> occursin(f, trig_text), ("sec(x)", "csc(x)", "cot(x)"))
             inv_hyperbolic_text = to_maxima(asinh(x) + atanh(x))
             @test all(f -> occursin(f, inv_hyperbolic_text), ("asinh(x)", "atanh(x)"))
+            @test to_maxima(erf(x)) == "erf(x)"
+            @test to_maxima(from_maxima("%e^(-2)", [])) == "exp(-2)"
+            @test to_maxima(gamma_incomplete(a, x)) == "gamma_incomplete(a,x)"
+            @test to_maxima(polylog(2, x)) == "li[2](x)"
             radical_text = to_maxima(z * ((z - 1)^(1 // 3)))
             @test occursin("z", radical_text)
             @test occursin("((-1+z)^(1/3))", radical_text)
         end
 
         @testset "Maxima parser errors" begin
-            @test_throws MaximaError from_maxima("unknown_maxima_function(x)", [x])
+            opaque = from_maxima("unknown_maxima_function(x)", [x])
+            @test to_maxima(opaque) == "unknown_maxima_function(x)"
+            opaque_indexed = from_maxima("unknown_maxima_function[2](x)", [x])
+            @test to_maxima(opaque_indexed) == "unknown_maxima_function[2](x)"
+            conversion_error = try
+                from_maxima("~%~a~%", [])
+            catch err
+                err
+            end
+            @test conversion_error isa MaximaError
+            @test conversion_error.kind === :conversion
             @test_throws MaximaError from_maxima("if x > 0 then x else -x", [x])
             @test_throws MaximaError from_maxima("integrate(foo(x),x)", [x])
-            @test_throws MaximaError maxima_call("integrate(x^n*log(a*x),x)")
+            assumption_error = try
+                maxima_call("integrate(x^n*log(a*x),x)")
+            catch err
+                err
+            end
+            @test assumption_error isa MaximaError
+            @test assumption_error.kind === :assumption
+            @test occursin("Is ", sprint(showerror, assumption_error))
             @test isequal(Symbolics.simplify(from_maxima("sec(x)", [x]) - sec(x)), 0)
             @test isequal(Symbolics.simplify(from_maxima("asinh(x)", [x]) - asinh(x)), 0)
             @test occursin("γ", string(from_maxima("%gamma", [])))
             @test occursin("φ", string(from_maxima("%phi", [])))
+            @test occursin("catalan", string(from_maxima("%catalan", [])))
+            @test Symbolics.value(from_maxima("inf", [])) == Inf
+            @test to_maxima(from_maxima("true", [])) == "true"
+            @test to_maxima(from_maxima("false", [])) == "false"
+            @test Symbolics.value(from_maxima("1.25b0", [])) == big"1.25"
             @test occursin("gamma_incomplete_lower", string(from_maxima("gamma_incomplete_lower(a,x)", [a, x])))
             @test occursin("hypergeometric", string(from_maxima("hypergeometric([1],[3/2],x)", [x])))
+            @test to_maxima(from_maxima("psi[0](x)", [x])) == "psi[0](x)"
+            @test to_maxima(from_maxima("li[2](x)", [x])) == "li[2](x)"
+            @test to_maxima(from_maxima("assoc_legendre_p[n,m](x)", [n, m, x])) ==
+                "assoc_legendre_p[n,m](x)"
+            hypergeometric_result = from_maxima("%f[1,1]([1],[3/2],x)", [x])
+            @test to_maxima(hypergeometric_result) == "hypergeometric([1],[3/2],x)"
         end
 
         @testset "Indefinite integrals" begin
@@ -221,10 +266,12 @@ end
             @test isequal(Symbolics.simplify(integrate(exp(a * x), x, method) - exp(a * x) / a), 0)
             @test isequal(Symbolics.simplify(integrate(exp(-(x^2)), x, method) - sqrt(Num(π)) * erf(x) / 2), 0)
             @test occursin("sqrt", string(integrate(exp(-(x^2)), x, method)))
-            @test occursin("gamma_incomplete", string(integrate(sin(x) / x, x, method; validate=false)))
-            @test occursin("gamma_incomplete", string(integrate(cos(x) / x, x, method; validate=false)))
-            @test occursin("gamma_incomplete", string(integrate(1 / log(x), x, method; validate=false)))
+            @test occursin("expintegral", string(integrate(sin(x) / x, x, method; validate=false)))
+            @test occursin("expintegral", string(integrate(cos(x) / x, x, method; validate=false)))
+            @test occursin("expintegral", string(integrate(1 / log(x), x, method; validate=false)))
             @test occursin("erf", string(integrate(exp(x^2), x, method; validate=false)))
+            @test occursin("erf", string(integrate(erf(x), x, method; validate=false)))
+            @test occursin("polylog", string(integrate(log(x) / (1 - x), x, method; validate=false)))
             parametric = integrate(x^n * log(a * x), x, method;
                 assumptions=(maxima_notequal(n, -1), a > 0), validate=false)
             expected = ((n + 1) * x^(n + 1) * log(a * x) - x^(n + 1)) / (n + 1)^2
@@ -242,9 +289,44 @@ end
             @test isequal(Symbolics.simplify(integrate(sin(π * x / L)^2, x, 0, L, method; assumptions=(L > 0,)) - L / 2), 0)
             @test isequal(Symbolics.simplify(integrate(exp(-a * x), x, 0, Inf, method; assumptions=(a > 0,)) - 1 / a), 0)
             @test isequal(integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, method; assumptions=(C > 0,)), 0)
-            @test_throws MaximaError integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, method)
+            positive_method = MaximaMethod(timeout=10, assumptions=(C > 0,))
+            @test isequal(integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, positive_method), 0)
+            assumption_error = try
+                integrate((C * x - 2) * x * exp(-C * x), x, 0, Inf, method)
+            catch err
+                err
+            end
+            @test assumption_error isa MaximaError
+            @test assumption_error.kind === :assumption
+            @test occursin("Is C positive, negative or zero?", sprint(showerror, assumption_error))
+            @test occursin("assumptions=(C > 0,)", sprint(showerror, assumption_error))
+
+            gamma_result = integrate(x^2 * exp(-x), x, 2, Inf, method)
+            @test !(gamma_result isa AbstractFloat)
+            @test isequal(Symbolics.simplify(gamma_result - 10 * exp(Num(-2))), 0)
+            @test isapprox(maxima_numeric(gamma_result), 10 * exp(-2); rtol=1e-14)
             atan_form = integrate(1 / (a + b * x^2), x, method; assumptions=(a > 0, b > 0))
             @test isequal(Symbolics.simplify(atan_form - atan(sqrt(b) * x / sqrt(a)) / (sqrt(a) * sqrt(b))), 0)
+        end
+
+        @testset "Utilities" begin
+            exact = maxima_simplify(gamma_incomplete(3, 2))
+            @test !(exact isa AbstractFloat)
+            @test isequal(Symbolics.simplify(exact - 10 * exp(Num(-2))), 0)
+            @test isapprox(maxima_numeric(gamma_incomplete(3, 2)), 10 * exp(-2); rtol=1e-14)
+            high_precision = maxima_numeric(gamma_incomplete(3, 2); digits=40)
+            @test high_precision isa BigFloat
+            @test isapprox(high_precision, 10 * exp(big(-2)); rtol=big"1e-38")
+            @test maxima_numeric(2) === 2.0
+            @test maxima_numeric(im) === 0.0 + 1.0im
+            @test maxima_numeric(im; digits=40) isa Complex{BigFloat}
+            @test_throws MaximaError maxima_numeric(1 / a)
+            @test_throws ArgumentError maxima_numeric(1; digits=1)
+            @test_throws ArgumentError maxima_call("1"; timeout=0)
+
+            help_output = IOBuffer()
+            @test isnothing(maxima_help(help_output))
+            @test occursin("assumptions", String(take!(help_output)))
         end
     end
 


### PR DESCRIPTION
## Summary

- surface concrete Maxima assumption questions instead of parser failures
- preserve exact constants and broaden special-function round-tripping
- add exact simplification, numerical evaluation, status, and help utilities
- document the backend and prepare SymbolicIntegrationMaxima v0.2.0

## Motivation

Parametric improper integrals could previously end in a raw parser error when Maxima asked for an assumption. Exact special-function values could also be converted to floating-point values too early, and unsupported Maxima functions stopped otherwise usable results from returning to Symbolics.

This update makes the backend suitable for interactive use while keeping assumptions explicit: the package does not silently choose mathematical domains or signs for the user.

## Behavior

The backend now:

- captures Maxima's assumption requests and reports which assumption is missing
- distinguishes assumption, timeout, process, parse, and unsupported-result failures
- preserves exact `%pi` and `%e`
- handles incomplete gamma values and common special functions more naturally
- preserves unknown Maxima functions as symbolic calls when possible
- provides `maxima_simplify`, `maxima_numeric`, `maxima_help`, and `maxima_status`
- documents installation, assumptions, improper integrals, simplification, and diagnostics

## Validation

- Julia 1.10: 90/90 basic tests passed
- Julia 1.12: 90/90 basic tests passed
- difficult corpus, 103 cases: 62 ok, 35 maybe, 0 fail, 4 unevaluated, 2 assumption-needed, 0 exceptions
- Documenter build and doctests passed
- `git diff --check` passed

## Release and registry

The subpackage version is bumped to `0.2.0`. After this PR is merged, the General registry source entry should first be updated to:

```toml
repo = "https://github.com/JuliaSymbolics/SymbolicIntegration.jl.git"
subdir = "lib/SymbolicIntegrationMaxima"
```

Then `0.2.0` can be registered from the merged commit. Existing entries in `Versions.toml`, especially the `0.1.1` tree hash, must remain unchanged.
