### PR TITLE
Configure TagBot for Maxima subpackage

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -25,7 +25,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - name: Tag SymbolicIntegration
+        uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+      - name: Tag SymbolicIntegrationMaxima
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          subdir: lib/SymbolicIntegrationMaxima


### PR DESCRIPTION
## Summary

Add a dedicated TagBot step for the `SymbolicIntegrationMaxima` subpackage.

## Why

`SymbolicIntegrationMaxima` is registered from `lib/SymbolicIntegrationMaxima`,
but the existing workflow only tags the top-level `SymbolicIntegration` package.
TagBot requires a separate step with `subdir` for packages in a monorepo. Without
it, registering a new backend version would not create the corresponding
subpackage-prefixed tag and GitHub release.

## Validation

- Parsed `.github/workflows/TagBot.yml` successfully with Ruby's YAML parser.
- `git diff --check` passes.

This is intentionally independent of #124 so the release automation can be
reviewed separately from the backend changes.
