### PR TITLE
Raise Maxima sublibrary SymbolicUtils floor from 4 to 4.3

### DIFF
--- a/lib/SymbolicIntegrationMaxima/Project.toml
+++ b/lib/SymbolicIntegrationMaxima/Project.toml
@@ -20,7 +20,7 @@ HypergeometricFunctions = "0.3.28"
 PolyLog = "2.6.0"
 SpecialFunctions = "2"
 SymbolicIntegration = "3"
-SymbolicUtils = "4"
+SymbolicUtils = "4.3"
 Symbolics = "7"
 julia = "1.10"
 


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Raise `lib/SymbolicIntegrationMaxima` `SymbolicUtils` floor from `4` to `4.3`.

The Maxima sublibrary declares `Symbolics = "7"` and `SymbolicUtils = "4"`. Every registered Symbolics 7.x requires SymbolicUtils ≥ 4.3.0. Pinning the declared SU 4.0.0 is unsatisfiable. Root SymbolicIntegration already declares `SymbolicUtils = "4.27"`; this only fixes the sublibrary.

No code or package version change.

### Fail before

Isolated-depot Julia 1.10.11, `Pkg.develop` live `lib/SymbolicIntegrationMaxima` + pin `SymbolicUtils 4.0.0`:

```
Unsatisfiable requirements detected for package SymbolicUtils
 restricted to versions 4 by SymbolicIntegrationMaxima
 restricted to versions 4.0.0 by an explicit requirement
 restricted by compatibility requirements with Symbolics
   to versions: 4.3.0-4.45.0 — no versions left
```

### Pass after

Pin `SymbolicUtils 4.3.0` (pulls Symbolics 7.0.0 and SymbolicIntegration 3.5.0):

```
RESOLVE_OK
Installed SymbolicUtils v4.3.0
```

First working registered version is **4.3.0** because it is the lower bound of every Symbolics 7 release. 4.0.0–4.2.x have no overlapping Symbolics 7.

Root `SymbolicUtils = "4.27"` and `Symbolics = "7"` were pinned and loaded (`LOAD_OK` SymbolicIntegration 3.7.0 + SU 4.27.0 and Symbolics 7.0.0); they are left unchanged.

Not verified here: full test suite, Maxima backend, or a live `julia-downgrade-compat` run.
