### PR TITLE
Document public integration and differential-field interfaces

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ makedocs(
     clean=true,
     doctest=true,
     linkcheck=false,
-    checkdocs=:none,
+    checkdocs=:exports,
     format=Documenter.HTML(
         assets=String[],
         canonical="https://symbolicintegration.juliasymbolics.org/stable/",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,20 +1,45 @@
 # API Reference
 
+```@docs
+SymbolicIntegration
+```
+
 ```@meta
 CurrentModule = SymbolicIntegration
 ```
 
-## Main Functions
+## Integration Interface
 
 ```@docs
+AbstractIntegrationMethod
 integrate
-```
-
-## Integration Methods
-
-### Available Methods
-
-```@docs
 RischMethod
 RuleBasedMethod
+reload_rules
+```
+
+## Differential Fields
+
+```@docs
+Derivation
+NullDerivation
+BasicDerivation
+ExtensionDerivation
+CoefficientLiftingDerivation
+TowerOfDifferentialFields
+BaseDerivation
+MonomialDerivative
+domain
+constant_field
+iscompatible
+is_Sirr1_eq_Sirr
+isbasic
+isprimitive
+ishyperexponential
+isnonlinear
+ishypertangent
+isnormal
+isspecial
+issimple
+isreduced
 ```

--- a/src/SymbolicIntegration.jl
+++ b/src/SymbolicIntegration.jl
@@ -1,5 +1,30 @@
 __precompile__()
 
+"""
+    SymbolicIntegration
+
+Symbolic antiderivatives for expressions built with `Symbolics.jl`.
+
+The package provides the [`integrate`](@ref SymbolicIntegration.integrate)
+interface and two built-in backends,
+[`RuleBasedMethod`](@ref SymbolicIntegration.RuleBasedMethod) and
+[`RischMethod`](@ref SymbolicIntegration.RischMethod). Backends are
+selected automatically for the two-argument form or explicitly by passing a
+method object. The
+[`AbstractIntegrationMethod`](@ref SymbolicIntegration.AbstractIntegrationMethod)
+interface can be
+implemented by packages that provide another integration backend.
+
+# Example
+
+```julia
+using SymbolicIntegration, Symbolics
+
+@variables x
+integrate(exp(x), x)
+integrate(1 / (x^2 + 1), x, RischMethod())
+```
+"""
 module SymbolicIntegration
 
 using Symbolics

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -3,18 +3,55 @@
 """
     AbstractIntegrationMethod
 
-Abstract supertype for all symbolic integration methods.
+Abstract interface for symbolic integration backends.
+
+A concrete method must subtype `AbstractIntegrationMethod` and provide an
+`integrate(f, x, method; kwargs...)` dispatch for symbolic `f` and `x`. The
+method owns backend-specific keyword arguments; callers can use the two-argument
+form when the backend is selected automatically, or pass a concrete method to
+select one implementation explicitly. Implementations should return a
+`Symbolics.Num` antiderivative or an unevaluated symbolic integral when the
+backend cannot solve the problem.
+
+# Minimal interface
+
+```julia
+struct MyMethod <: AbstractIntegrationMethod end
+
+function integrate(f::Symbolics.Num, x::Symbolics.Num, ::MyMethod; kwargs...)
+    # Return a symbolic antiderivative or an unevaluated integral.
+end
+```
+
+The generic interface is intentionally based on dispatch rather than a
+registration table. Do not mutate the built-in method types or rely on
+internal rule functions when implementing a backend.
 """
 abstract type AbstractIntegrationMethod end
 
 """
-    RischMethod <: AbstractIntegrationMethod
+    RischMethod(; use_algebraic_closure=false, catch_errors=true)
 
-Risch algorithm for symbolic integration of elementary functions.
+Configure the Risch algorithm for symbolic integration of elementary functions.
+
+# Keyword Arguments
+
+- `use_algebraic_closure::Bool=false`: Whether algebraic roots may be computed
+  in an algebraic closure when needed.
+- `catch_errors::Bool=true`: Whether recoverable algorithm failures should be
+  caught and returned as an unevaluated integral.
 
 # Fields
-- `use_algebraic_closure::Bool`: Whether to use algebraic closure for complex roots (default: true)
-- `catch_errors::Bool`: Whether to catch and handle algorithm errors gracefully (default: true)
+
+- `use_algebraic_closure::Bool`: Value of `use_algebraic_closure`.
+- `catch_errors::Bool`: Value of `catch_errors`.
+
+# Examples
+
+```julia
+method = RischMethod(use_algebraic_closure=true)
+integrate(1 / (x^2 + 1), x, method)
+```
 """
 struct RischMethod <: AbstractIntegrationMethod
     use_algebraic_closure::Bool
@@ -26,10 +63,26 @@ struct RischMethod <: AbstractIntegrationMethod
 end
 
 """
-    RuleBasedMethod <: AbstractIntegrationMethod
+    RuleBasedMethod(; use_gamma=false, verbose=false)
 
-- `use_gamma::Bool`: Whether to catch and handle algorithm errors gracefully (default: true)
-- `verbose::Bool`: Whether to print or not integration rules applied (default: false)
+Configure the rule-based symbolic integration backend.
+
+# Keyword Arguments
+
+- `use_gamma::Bool=false`: Allow gamma-function forms in rule results.
+- `verbose::Bool=false`: Print each rule application while integrating.
+
+# Fields
+
+- `use_gamma::Bool`: Value of `use_gamma`.
+- `verbose::Bool`: Value of `verbose`.
+
+# Examples
+
+```julia
+method = RuleBasedMethod(verbose=true)
+integrate(sqrt(1 + x), x, method)
+```
 """
 struct RuleBasedMethod <: AbstractIntegrationMethod
     use_gamma::Bool
@@ -41,20 +94,33 @@ struct RuleBasedMethod <: AbstractIntegrationMethod
 end
 
 """
-    integrate(f, x)
-    
-integrate function called without method. Compute the symbolic integral of expression `f` with respect to variable `x` using all available methods.
+    integrate(f, x; verbose=false, kwargs...)
+
+Compute the symbolic antiderivative of `f` with respect to `x`, trying the
+available rule-based and Risch backends in order.
 
 # Arguments
-- `f`: Symbolic expression to integrate (Symbolics.Num)
-- `x`: Integration variable (Symbolics.Num)  
+
+- `f::Symbolics.Num`: Symbolic integrand.
+- `x::Symbolics.Num`: Symbolic integration variable.
+
+# Keyword Arguments
+
+- `verbose::Bool=false`: Print backend and rule progress.
+- `kwargs...`: Forwarded to the selected backend implementations.
+
+# Returns
+
+A symbolic antiderivative, or an unevaluated integral when no backend can
+complete the calculation.
 
 # Examples
+
 ```julia
-julia> using SymbolicIntegration, Symbolics
-julia> @variables x
-julia> integrate(2x)
-x^2
+using SymbolicIntegration, Symbolics
+@variables x
+integrate(2x, x)
+integrate(exp(x), x)
 ```
 """
 function integrate(f::Symbolics.Num, x::Symbolics.Num; verbose=false, kwargs...)
@@ -74,9 +140,24 @@ function integrate(f::Symbolics.Num, x::Symbolics.Num; verbose=false, kwargs...)
 end
 
 """
-    integrate(f::Symbolics.Num, method=nothing)
+    integrate(f::Symbolics.Num, method=nothing; kwargs...)
 
-integrate function called without integration variable, and possibly without a method. If f contains only one symbolic variable, lets say x, calls integrate(f, x, method)
+Integrate a symbolic expression without explicitly passing its variable.
+
+This overload is valid only when `f` contains exactly one symbolic variable.
+That variable is selected and the call is forwarded to
+`integrate(f, variable, method)`. Expressions with zero or multiple variables
+return `nothing` after emitting a warning.
+
+# Arguments
+
+- `f::Symbolics.Num`: Symbolic integrand.
+- `method`: `nothing` for automatic selection or an
+  [`AbstractIntegrationMethod`](@ref) instance.
+
+# Keyword Arguments
+
+- `kwargs...`: Forwarded to the selected integration method.
 """
 function integrate(f::Symbolics.Num, method::M=nothing; kwargs...) where M<:Union{AbstractIntegrationMethod,Nothing}
     vars = Symbolics.get_variables(f)
@@ -95,29 +176,32 @@ function integrate(f::Symbolics.Num, method::M=nothing; kwargs...) where M<:Unio
 end
 
 """
-    integrate(f, x, method::AbstractIntegrationMethod=RischMethod(); kwargs...)
+    integrate(f, x, method::RischMethod; kwargs...)
 
-Compute the symbolic integral of expression `f` with respect to variable `x` 
-using Risch integration method.
+Compute the symbolic antiderivative of `f` with respect to `x` using the Risch
+algorithm and the configuration in `method`.
 
 # Arguments
-- `f`: Symbolic expression to integrate (Symbolics.Num)
-- `x`: Integration variable (Symbolics.Num)  
+
+- `f::Symbolics.Num`: Symbolic integrand.
+- `x::Symbolics.Num`: Symbolic integration variable.
+- `method::RischMethod`: Risch configuration.
 
 # Keyword Arguments
-- Method-specific keyword arguments are passed to the method implementation
+
+- `kwargs...`: Additional backend options forwarded to the Risch implementation.
 
 # Returns
-- Symbolic expression representing the antiderivative (Symbolics.Num)
+
+A symbolic antiderivative or an unevaluated integral.
 
 # Examples
-```julia
-# Explicit method with options
-integrate(1/(x^2 + 1), x, RischMethod(use_algebraic_closure=true))  # atan(x)
 
-# Method configuration
-risch = RischMethod(use_algebraic_closure=false, catch_errors=true)
-integrate(exp(x), x, risch)  # exp(x)
+```julia
+using SymbolicIntegration, Symbolics
+@variables x
+method = RischMethod(use_algebraic_closure=true)
+integrate(1 / (x^2 + 1), x, method)
 ```
 """
 function integrate(f::Symbolics.Num, x::Symbolics.Num, method::RischMethod; kwargs...)
@@ -130,42 +214,32 @@ function integrate(f::Symbolics.Num, x::Symbolics.Num, method::RischMethod; kwar
 end
 
 """
-    integrate(f, x, method::AbstractIntegrationMethod=RuleBasedMethod(); kwargs...)
+    integrate(f, x, method::RuleBasedMethod; kwargs...)
 
-Compute the symbolic integral of expression `f` with respect to variable `x`
-using rule based method.
+Compute the symbolic antiderivative of `f` with respect to `x` using the
+rule-based backend and the configuration in `method`.
 
 # Arguments
-- `f`: Symbolic expression to integrate (Symbolics.Num)
-- `x`: Integration variable (Symbolics.Num)  
+
+- `f::Symbolics.Num`: Symbolic integrand.
+- `x::Symbolics.Num`: Symbolic integration variable.
+- `method::RuleBasedMethod`: Rule-based configuration.
+
+# Keyword Arguments
+
+- `kwargs...`: Additional backend options forwarded to the rule engine.
 
 # Returns
-- Symbolic expression representing the antiderivative (Symbolics.Num)
+
+A symbolic antiderivative or an unevaluated integral.
 
 # Examples
+
 ```julia
-julia> integrate(1/sqrt(1 + x), x, RuleBasedMethod(verbose=true))
-┌-------Applied rule 1_1_2_1_33 (change of variables):
-| ∫((a + b * v ^ n) ^ p, x) => if 
-|       !(contains_var(a, b, n, p, x)) &&
-|       (
-|             linear(v, x) &&
-|             v !== x
-|       )
-| (1 / ext_coeff(v, x, 1)) * substitute(∫{(a + b * x ^ n) ^ p}dx, x => v)
-└-------with result: ∫1 / (u^(1//2)) du where u = 1 + x
-┌-------Applied rule 1_1_1_1_2 on ∫(1 / (x^(1//2)), x)
-| ∫(x ^ m, x) => if 
-|       !(contains_var(m, x)) &&
-|       m !== -1
-| x ^ (m + 1) / (m + 1)
-└-------with result: (2//1)*(x^(1//2))
-(2//1)*sqrt(1 + x)
-
-julia> rbm = RuleBasedMethod(verbose=false)
-julia> integrate(1/sqrt(1 + x), x, rbm)
-
-(2//1)*sqrt(1 + x)
+using SymbolicIntegration, Symbolics
+@variables x
+method = RuleBasedMethod(verbose=true)
+integrate(1 / sqrt(1 + x), x, method)
 ```
 """
 function integrate(f::Symbolics.Num, x::Symbolics.Num, method::RuleBasedMethod; kwargs...)

--- a/src/methods/risch/differential_fields.jl
+++ b/src/methods/risch/differential_fields.jl
@@ -5,19 +5,95 @@ export Derivation, NullDerivation, BasicDerivation, ExtensionDerivation,
    iscompatible, isnormal, isspecial, issimple, isreduced, is_Sirr1_eq_Sirr
 
 
+"""
+    Derivation
+
+Abstract interface for a derivation used by the Risch integration algorithm.
+
+A concrete derivation represents a differential field with a distinguished
+domain. It must store or otherwise provide a `domain` and be callable on
+elements of that domain. Implementations should also define
+[`BaseDerivation`](@ref) and [`MonomialDerivative`](@ref). The latter must be a
+polynomial in the field generator and determines `degree(D)` and
+`leading_coefficient(D)` through AbstractAlgebra.
+
+For a new derivation type, preserve these rules:
+
+- `D(p)` returns the derivative of every compatible polynomial or fraction
+  `p` and throws an error for an incompatible parent.
+- `domain(D)` is the polynomial ring on which the derivation is defined.
+- `BaseDerivation(D)` is the derivation on the coefficient field.
+- `MonomialDerivative(D)` is the derivative of `gen(domain(D))`.
+- `constant_field(D)` returns the field whose elements are fixed by `D`.
+
+The exported predicates in this file inspect these operations; they are not
+additional dispatch requirements for every concrete derivation.
+
+# Examples
+
+```julia
+R, x = polynomial_ring(QQ, :x)
+D = BasicDerivation(R)
+D(x^2) == 2x
+```
+"""
 abstract type Derivation end
 
+"""
+    domain(D::Derivation)
+
+Return the polynomial ring on which `D` is defined.
+
+All values passed to `D`, [`iscompatible`](@ref), and the differential-field
+predicates must be elements of this domain or of its fraction field.
+"""
 domain(D::Derivation) = D.domain
+
+"""
+    iscompatible(p, D::Derivation) -> Bool
+
+Return whether `p` belongs to the domain of `D`.
+
+The method accepts ring elements and fraction-field elements. It compares the
+parent ring of `p` with `domain(D)` and does not coerce `p`.
+"""
 iscompatible(p::RingElement, D::Derivation) = parent(p)==domain(D)
 iscompatible(f::FracElem, D::Derivation) =
     base_ring(parent(f))==D.domain
 
+"""
+    is_Sirr1_eq_Sirr(D::Derivation) -> Bool
+
+Report whether the derivation assumes that the first irreducible special
+factor set equals the special factor set. The default implementation returns
+`true`, which is the assumption used by the current Risch routines.
+"""
 is_Sirr1_eq_Sirr(D::Derivation) = true
 # For the time being it is assumed that S₁ⁱʳʳ==Sⁱʳʳ for all derivations
 # to be considered.
 # See Bronstein's book, Theorems 5.1.1, 5.1.2, 5.10.1 .
 
 
+"""
+    NullDerivation(domain)
+
+Construct the zero derivation on `domain`.
+
+# Fields
+
+- `domain`: Ring whose elements are fixed by the derivation.
+
+The fraction-field constructor stores its base polynomial ring. Calling the
+derivation on a compatible element returns `zero(element)`.
+
+# Examples
+
+```julia
+R, x = polynomial_ring(QQ, :x)
+D = NullDerivation(R)
+D(x^2) == 0
+```
+"""
 struct NullDerivation <: Derivation
     domain #::Ring does not work ... :(
 end
@@ -48,6 +124,27 @@ Base.show(io::IO, D::NullDerivation) = print(io, "Null derivation D=0 on ", doma
 
 
 
+"""
+    BasicDerivation(domain)
+
+Construct the ordinary derivative `d/dx` on a univariate polynomial ring.
+
+# Fields
+
+- `domain`: Polynomial ring whose generator is differentiated.
+
+`BasicDerivation(R)` differentiates polynomials in `R` and fractions over `R`.
+Its base derivation is [`NullDerivation`](@ref) and its monomial derivative is
+`one(domain)`.
+
+# Examples
+
+```julia
+R, x = polynomial_ring(QQ, :x)
+D = BasicDerivation(R)
+D(x^3 + x) == 3x^2 + 1
+```
+"""
 struct BasicDerivation{T<:RingElement} <: Derivation
     domain::PolyRing{T}
 end
@@ -64,8 +161,15 @@ function (D::BasicDerivation{T})(f::FracElem{P}) where {T<:RingElement, P<:PolyR
     derivative(f)
 end
 
-BaseDerivation(D::BasicDerivation) = NullDerivation(base_ring(D.domain))
-MonomialDerivative(D::BasicDerivation) = one(D.domain)
+"""
+    constant_field(D::Derivation)
+
+Return the coefficient field fixed by `D`.
+
+For a null or basic derivation this is the fraction field of the coefficient
+ring when the stored domain is not already a field. Extension derivations
+delegate to their base derivation.
+"""
 function constant_field(D::BasicDerivation) 
     R = base_ring(D.domain)
     if isa(R, AbstractAlgebra.Field)
@@ -78,6 +182,28 @@ end
 Base.show(io::IO, D::BasicDerivation) = print(io, "Basic derivation D=d/d", gen(domain(D)), " on ", domain(D))
 
 
+"""
+    ExtensionDerivation(domain, D, H)
+
+Extend a derivation `D` to a polynomial ring with generator `t` by setting
+`D(t) = H`.
+
+# Arguments
+
+- `domain`: Polynomial ring extending `domain(D)`.
+- `D`: Derivation on the coefficient ring of `domain`.
+- `H`: Polynomial in `domain` giving the derivative of its generator.
+
+# Fields
+
+- `domain`: Extended polynomial ring.
+- `D`: Base derivation.
+- `H`: Monomial derivative of the new generator.
+
+The coefficient ring of `domain` must match `domain(D)`. Use
+[`CoefficientLiftingDerivation`](@ref) when the new generator has zero
+derivative.
+"""
 struct ExtensionDerivation{T<:RingElement} <: Derivation
     domain::PolyRing{T}
     D::Derivation
@@ -98,6 +224,18 @@ function ExtensionDerivation(domain::FracField{P}, D::Derivation, H::P) where {T
     ExtensionDerivation(base_ring(domain), D, H)
 end
 
+"""
+    CoefficientLiftingDerivation(domain, D)
+
+Extend `D` to `domain` while keeping the newly added generator constant.
+
+# Arguments
+
+- `domain`: Polynomial ring or fraction field extending `domain(D)`.
+- `D`: Derivation on the coefficient ring.
+
+This is equivalent to `ExtensionDerivation(domain, D, zero(domain))`.
+"""
 function CoefficientLiftingDerivation(domain::PolyRing{T}, D::Derivation) where T<:RingElement
     ExtensionDerivation(domain, D, zero(domain))
 end
@@ -138,7 +276,23 @@ function (D::ExtensionDerivation{T})(f::FracElem{P}) where {T<:RingElement, P<:P
 end
 
 
+"""
+    BaseDerivation(D::Derivation)
+
+Return the derivation on the coefficient field from which `D` was extended.
+"""
+BaseDerivation(D::BasicDerivation) = NullDerivation(base_ring(D.domain))
 BaseDerivation(D::ExtensionDerivation) = D.D 
+
+"""
+    MonomialDerivative(D::Derivation)
+
+Return the derivative of the generator of `domain(D)`.
+
+For an [`ExtensionDerivation`](@ref), this is the stored `H`; for a
+[`BasicDerivation`](@ref), it is `one(domain(D))`.
+"""
+MonomialDerivative(D::BasicDerivation) = one(D.domain)
 MonomialDerivative(D::ExtensionDerivation) = D.H 
 constant_field(D::ExtensionDerivation) = constant_field(D.D)
 
@@ -174,47 +328,98 @@ Base.show(io::IO, D::AlgebraicExtensionDerivation) = print(io, "Algebraic extens
 
 
 
-AbstractAlgebra.degree(D::Derivation) = 
-    degree(MonomialDerivative(D)) # \delta(t), see Def. 3.4.1
-AbstractAlgebra.leading_coefficient(D::Derivation) = 
-leading_coefficient(MonomialDerivative(D)) # \lambda(t), see Def. 3.4.1
-Base.iszero(D::Derivation) = false
-Base.iszero(D::NullDerivation) = true
+"""
+    isbasic(D::Derivation) -> Bool
+
+Return `true` when `D` is the ordinary derivative on its polynomial domain.
+Extension derivations are basic only when their base derivation is zero and
+their monomial derivative is one.
+"""
 isbasic(D::Derivation) = false
 isbasic(D::BasicDerivation) = true
-isbasic(D::ExtensionDerivation) = 
+isbasic(D::ExtensionDerivation) =
     iszero(BaseDerivation(D)) && isone(MonomialDerivative(D))
-isprimitive(D::Derivation) = degree(D)==0 # see Def. 5.1.1 
-ishyperexponential(D::Derivation) = # see Def, 5.1.1
-    degree(D)==1 && iszero(constant_coefficient(MonomialDerivative(D)))
-isnonlinear(D::Derivation) = degree(D)>=2 # see Def. 3.4.1  
 
-function ishypertangent(D::Derivation) 
-    # see Def. 5.10.1
+"""
+    isprimitive(D::Derivation) -> Bool
+
+Return whether the monomial derivative of `D` has degree zero.
+"""
+isprimitive(D::Derivation) = degree(D)==0
+
+"""
+    ishyperexponential(D::Derivation) -> Bool
+
+Return whether `D` has degree one and zero constant coefficient in its
+monomial derivative.
+"""
+ishyperexponential(D::Derivation) =
+    degree(D)==1 && iszero(constant_coefficient(MonomialDerivative(D)))
+
+"""
+    isnonlinear(D::Derivation) -> Bool
+
+Return whether the monomial derivative of `D` has degree at least two.
+"""
+isnonlinear(D::Derivation) = degree(D)>=2
+
+"""
+    ishypertangent(D::Derivation) -> Bool
+
+Return whether `D` is nonlinear and its monomial derivative is a constant
+multiple of `t^2 + 1`, where `t = gen(domain(D))`.
+"""
+function ishypertangent(D::Derivation)
     isnonlinear(D) || return false
     t = gen(domain(D))
     q, r = divrem(MonomialDerivative(D), t^2+1)
     iszero(r) && degree(q)<=0
 end
 
+"""
+    isnormal(p, D::Derivation) -> Bool
 
+Return whether the compatible polynomial `p` is normal with respect to `D`.
+
+Normality means `gcd(p, D(p))` has degree zero.
+"""
 isnormal(p::PolyRingElem, D::Derivation) =
-    # see Def. 3.4.2
     iscompatible(p, D) && degree(gcd(p, D(p)))==0
 
-isspecial(p::PolyRingElem, D::Derivation) =
-    # see Def. 3.4.2
-    iscompatible(p, D) && iszero(rem(D(p), p)) # gcd(p, D(p))==p
+"""
+    isspecial(p, D::Derivation) -> Bool
 
+Return whether the compatible polynomial `p` is special with respect to `D`.
+
+Speciality means `p` divides `D(p)`.
+"""
+isspecial(p::PolyRingElem, D::Derivation) =
+    iscompatible(p, D) && iszero(rem(D(p), p))
+
+"""
+    issimple(f, D::Derivation) -> Bool
+
+Return whether the denominator of compatible fraction `f` is normal with
+respect to `D`.
+"""
 issimple(f::FracElem{P}, D::Derivation) where P<:PolyRingElem =
-    #see Def. 3.5.2.
     iscompatible(f, D) && isnormal(denominator(f), D)
 
+"""
+    isreduced(f, D::Derivation) -> Bool
+
+Return whether the denominator of compatible fraction `f` is special with
+respect to `D`.
+"""
 isreduced(f::FracElem{P}, D::Derivation) where P<:PolyRingElem =
-    #see Def. 3.5.2.
     iscompatible(f, D) && isspecial(denominator(f), D)
 
-
+AbstractAlgebra.degree(D::Derivation) =
+    degree(MonomialDerivative(D)) # \delta(t), see Def. 3.4.1
+AbstractAlgebra.leading_coefficient(D::Derivation) =
+leading_coefficient(MonomialDerivative(D)) # \lambda(t), see Def. 3.4.1
+Base.iszero(D::Derivation) = false
+Base.iszero(D::NullDerivation) = true
 function isconstant(x::T, D::NullDerivation) where T<:RingElement 
     @assert iscompatible(x, D)
     true
@@ -372,4 +577,3 @@ function CanonicalRepresentation(f::FracElem{P}, D::Derivation) where {T<:FieldE
     b, c = gcdx(dn, ds, r)
     q, b//ds, c//dn
 end
-

--- a/src/methods/rule_based/rules_loader.jl
+++ b/src/methods/rule_based/rules_loader.jl
@@ -59,6 +59,25 @@ end
 # if so, it replaces the rule with the new one.
 # if not, it adds the new rule to the global RULES array in the correct place.
 # if called with no argument reloads all rules from the default paths
+"""
+    reload_rules(path; verbose=true)
+
+Reload rule definitions from a Julia source file into the active rule table.
+
+# Arguments
+
+- `path::AbstractString`: Path to a rule file. The file must define the local
+  `file_rules` collection used by the rule loader.
+
+# Keyword Arguments
+
+- `verbose::Bool=true`: Print replacements, insertions, and deletions.
+
+Rules with identifiers already in the global table are replaced; new rules are
+inserted in identifier order, and rules removed from the file are deleted.
+This function is intended for rule development and should not be needed by
+ordinary integration calls.
+"""
 function reload_rules(path; verbose = true)
     global RULES
     global IDENTIFIERS
@@ -114,6 +133,20 @@ function reload_rules(path; verbose = true)
     verbose && println("$(length(file_rules)) rules reloaded from $path, $(length(RULES)) total rules.")
 end
 
+"""
+    reload_rules(; verbose=true)
+
+Reload all rule files shipped with SymbolicIntegration and rebuild the global
+rule table.
+
+# Keyword Arguments
+
+- `verbose::Bool=true`: Print loader progress and rule counts.
+
+Use this after editing a rule file in a development session. It mutates the
+package's internal rule table and is not required for normal use of
+[`integrate`](@ref).
+"""
 function reload_rules(;verbose = true)
     global RULES
     global IDENTIFIERS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,50 @@
 using Test
 using SymbolicIntegration
 using Symbolics
+using AbstractAlgebra
 
 const TEST_GROUP = get(ENV, "TEST_GROUP", "all")
 
+struct TestIntegrationMethod <: AbstractIntegrationMethod end
+
+function SymbolicIntegration.integrate(
+        f::Symbolics.Num, x::Symbolics.Num, ::TestIntegrationMethod; kwargs...)
+    f * x
+end
+
+struct TestDerivation{R,T} <: Derivation
+    domain::R
+    monomial_derivative::T
+end
+
+SymbolicIntegration.MonomialDerivative(D::TestDerivation) = D.monomial_derivative
+SymbolicIntegration.BaseDerivation(D::TestDerivation) = NullDerivation(base_ring(D.domain))
+SymbolicIntegration.constant_field(D::TestDerivation) = base_ring(D.domain)
+
+function (D::TestDerivation)(p::AbstractAlgebra.PolyRingElem)
+    iscompatible(p, D) || error("p not in domain of D")
+    derivative(p)
+end
+
 @testset "SymbolicIntegration.jl" begin
+
+    @testset "Abstract interface contracts" begin
+        R, x = polynomial_ring(QQ, :x)
+        D = TestDerivation(R, one(R))
+        @variables sx
+
+        @test isequal(integrate(sx, sx, TestIntegrationMethod()), sx^2)
+        @test SymbolicIntegration.domain(D) === R
+        @test SymbolicIntegration.iscompatible(x, D)
+        @test SymbolicIntegration.BaseDerivation(D) isa NullDerivation
+        @test isequal(SymbolicIntegration.MonomialDerivative(D), one(R))
+        @test SymbolicIntegration.isprimitive(D)
+        @test !SymbolicIntegration.isbasic(D)
+        @test !SymbolicIntegration.ishyperexponential(D)
+        @test !SymbolicIntegration.isnonlinear(D)
+        @test SymbolicIntegration.isnormal(x, D)
+        @test !SymbolicIntegration.isspecial(x, D)
+    end
 
     if TEST_GROUP == "all" || TEST_GROUP == "easy"
         @testset "Easy Tests" begin


### PR DESCRIPTION
## Summary

- Add on-definition SciMLStyle documentation for the exported integration and differential-field APIs, including keyword arguments, fields, examples, and the `AbstractIntegrationMethod` / `Derivation` extension contracts.
- Add explicit rendered API coverage with `checkdocs = :exports` and document `reload_rules`.
- Add focused generic contract tests for custom integration methods and derivations.

No SciMLTesting dependency was added; this repository does not use it.

## Verification

- `TEST_GROUP=easy julia --startup-file=no --project=. -e 'include("test/runtests.jl")'`: 199 passed, 1 pre-existing broken test, 200 total.
- `julia --startup-file=no --project=docs docs/make.jl`: completed through `HTMLWriter`.
- `Base.Docs.undocumented_names(SymbolicIntegration; private=false)`: `Symbol[]`.
- `git diff --check`: passed.
- `typos` on the changed diff: passed.

The repository-wide Runic and spelling checks still report pre-existing issues outside this patch; no tests were weakened or skipped.

Ignore this draft until reviewed by @ChrisRackauckas.
