### PR TITLE
fix: build `MatchDict` with its own constructor

### DIFF
--- a/src/methods/rule_based/rule2.jl
+++ b/src/methods/rule_based/rule2.jl
@@ -153,7 +153,7 @@ function check_expr_r(data::SymsType, rule::Expr, matches::MatchDict)::MatchDict
         !iscall(data) && return FAIL_DICT::MatchDict
         (Symbol(operation(data)) !== rule.args[1]) && return FAIL_DICT::MatchDict
         # return the whole data (not only vector of arguments as in rule1)
-        return Base.ImmutableDict(matches, rule.args[2].args[2].args[2], data)::MatchDict
+        return MatchDict(matches, rule.args[2].args[2].args[2], data)::MatchDict
     end
 
     # ((4)) rational is a special case, in the integration rules is present only in between numbers, like 1//2
@@ -312,11 +312,11 @@ helper function for when you reach the end of the symbolic tree and you either:
             # printdb(5, "about to check defslot predicate $pred with eval")
             !Base.invokelatest(eval(pred),SymbolicUtils.unwrap_const(value_matched)) && return FAIL_DICT
             # printdb(4, "adding defslot match $(rule_symbol.args[1]) => $value_matched")
-            return Base.ImmutableDict(current_dict, rule_symbol.args[1], value_matched)::MatchDict
+            return MatchDict(current_dict, rule_symbol.args[1], value_matched)::MatchDict
         end
         # if no predicate add match
         # printdb(4, "adding defslot match $rule_symbol => $value_matched to rditct: $(current_dict...)")
-        return Base.ImmutableDict(current_dict, rule_symbol, value_matched)::MatchDict
+        return MatchDict(current_dict, rule_symbol, value_matched)::MatchDict
     end
 end
 


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## What changed and why

`rule2.jl` built its match dictionaries with `Base.ImmutableDict(d, k, v)` in three places. Base defines no untyped three-argument `ImmutableDict` constructor — that call only ever resolved because SymbolicUtils pirated the method, and [SymbolicUtils v4.46.0 removed it](https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/3aeef075d36be1ef13bffaffbfa5b646594a2b7a). As a result **SymbolicIntegration 3.7.0 no longer precompiles against SymbolicUtils 4.46.0**, which the resolver will pick by default (compat is `SymbolicUtils = "4.27"`).

`MatchDict` is already `Base.ImmutableDict{Symbol, SymsType}`, so using it directly is both correct and clearer than the untyped form.

## Verification

Julia 1.12.7, `SymbolicUtils v4.46.0` + `Symbolics v7.37.0` — i.e. the combination that is broken today.

Before (this branch with `src/methods/rule_based/rule2.jl` reverted) — the failure is at *precompile* time:

```
Loaded 3391 rules from 100 files.
ERROR: LoadError: MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{Symbol, …BasicSymbolicImpl…}, ::Symbol, ::…BasicSymbolicImpl…)
The type `Base.ImmutableDict` exists, but no method is defined for this combination of argument types when trying to construct it.
Closest candidates are:
  Base.ImmutableDict(::Base.ImmutableDict{K, V}, !Matched::Pair) where {K, V}
```

After:

```
OK   ∫exp(x) = ℯ^x
OK   ∫cos(x)*sin(x) = (sin(x)^2) / 2
OK   ∫1 / (1 + x^2) = atan(x)
OK   ∫exp(x)*(x^2) = -2(-(ℯ^x) + (ℯ^x)*x) + (ℯ^x)*(x^2)
```

Full `Pkg.test()`:

```
Test Summary:          | Pass  Broken  Total     Time
SymbolicIntegration.jl |  204       1    205  6m37.4s
     Testing SymbolicIntegration tests passed
```

`typos` clean on the diff.

No dedicated regression test was added: loading the package *is* the test, and the suite cannot run at all without this change.

## Not verified

- Documentation and maxima workflows.
- The run reported baseline drift in the difficult-integral scoreboard (1 RuleBased and 5 Risch entries now scoring better than `test/difficult_baseline.jl` expects). That is environment drift from the newer Symbolics/SymbolicUtils, **not** from this change — Risch does not touch `rule2.jl` at all. I did not retune the baseline here; it wants its own PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73qSfpoV1bHGbknXLX9Q2
