### PR TITLE
Add a LICENSE to lib/SymbolicIntegrationMaxima

### DIFF
--- a/lib/SymbolicIntegrationMaxima/LICENSE
+++ b/lib/SymbolicIntegrationMaxima/LICENSE
@@ -1,0 +1,21 @@
+SymbolicIntegration.jl is licensed under the MIT License:
+
+Copyright (c) 2022 Harald Hofstätter, Mattia Micheletta Merlin, Chris Rackauckas, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The SymbolicIntegrationMaxima v0.2.0 registration (JuliaRegistries/General#163467) has been blocked since 2026-08-05 on `No licenses detected in the package's top-level folder`. AutoMerge looks inside the `subdir` being registered, and the MIT license only exists at the repository root. Copy it into the sublibrary folder so the package it registers carries its own license; the terms are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R